### PR TITLE
Assign IDs to all user signups

### DIFF
--- a/src/data.txt
+++ b/src/data.txt
@@ -1,2 +1,2 @@
-Ahmad Waqar:ahmadwaq2008@gmail.com:1234
-Ahmad:ahmad@gmail.com:123
+1:Ahmad Waqar:ahmadwaq2008@gmail.com:1234
+2:Ahmad:ahmad@gmail.com:123


### PR DESCRIPTION
## Summary
- store signup info in `src/data.txt` with a unique user id
- assign ids when loading existing data
- include ids in `/login`, `/signup`, and `/google-auth` routes

## Testing
- `python3 -m py_compile main.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a93cb8e10832e9542773af4bcba5d