### PR TITLE
Fix graph not filling container

### DIFF
--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -27,7 +27,10 @@ const SampleGraph = ({
   const [dot, setDot] = useState("digraph DNSSEC {}");
   const [loading, setLoading] = useState(false);
   const [summary, setSummary] = useState(null);
-  const graphvizOptions = useMemo(() => ({ engine: "dot" }), []);
+  const graphvizOptions = useMemo(
+    () => ({ engine: "dot", width: "100%", height: "100%" }),
+    []
+  );
   const GRAPH_SCALE = 2;
   /**
    * Build a Graphviz dot string from API data.
@@ -221,8 +224,8 @@ const SampleGraph = ({
                 initialScale={GRAPH_SCALE}
                 wheel={{ step: 0.1 }}
                 doubleClick={{ disabled: true }}
-                wrapperStyle={{ width: "200%", height: "100%" }}
-                contentStyle={{ width: "200%", height: "100%" }}
+                wrapperStyle={{ width: "100%", height: "100%" }}
+                contentStyle={{ width: "100%", height: "100%" }}
               >
                 {() => (
                   <>


### PR DESCRIPTION
## Summary
- ensure Graphviz fills entire container
- remove double-width transform wrapper

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6875270b3c04832eb8d5a24a7a33c3e2