### PR TITLE
Improve footer and sign-in button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -382,7 +382,19 @@ export default function App() {
             ) : (
               <User className="h-6 w-6 text-foreground" />
             )}
-            <p className="text-lg text-foreground">{username}</p>
+            {username && (
+              <p className="text-lg text-foreground">{username}</p>
+            )}
+            {!username && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setLoginOpen(true)}
+                type="button"
+              >
+                Sign in
+              </Button>
+            )}
             {username && (
               <Button variant="secondary" size="sm" onClick={handleLogout} type="button">
                 Log out
@@ -451,6 +463,20 @@ export default function App() {
           />
         </div>
       </main>
+        <footer className="border-t border-border bg-card text-card-foreground p-4 text-sm">
+          <div className="max-w-7xl mx-auto flex flex-col sm:flex-row justify-between gap-4">
+            <div>
+              <p className="font-semibold">DNSCAP</p>
+              <p className="text-xs">Demo dashboard for domain analysis.</p>
+            </div>
+            <div className="flex space-x-4">
+              <a href="#" className="hover:underline">Docs</a>
+              <a href="#" className="hover:underline">API</a>
+              <a href="#" className="hover:underline">Support</a>
+            </div>
+            <p className="text-xs sm:text-sm">&copy; 2024 DNSCAP. All rights reserved.</p>
+          </div>
+        </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- hide empty username label and show Sign in button when logged out
- fill the footer with a sample layout and links

## Testing
- `npm run lint`
- `npm run build`
- `python3 -m py_compile test.py test2.py`


------
https://chatgpt.com/codex/tasks/task_e_68755da13e00832ea2c905d87a3eaa6d