### PR TITLE
Add zoom controls and center Graphviz viewer

### DIFF
--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -30,8 +30,17 @@ const SampleGraph = ({
   const [dot, setDot] = useState("digraph DNSSEC {}");
   const [loading, setLoading] = useState(false);
   const [summary, setSummary] = useState(null);
+  const [zoomLevel, setZoomLevel] = useState(1);
   const graphvizOptions = useMemo(
     () => ({ engine: "dot", width: "100%", height: "100%", zoom: true }),
+    []
+  );
+  const handleZoomIn = useCallback(
+    () => setZoomLevel((z) => Math.min(z * 1.2, 5)),
+    []
+  );
+  const handleZoomOut = useCallback(
+    () => setZoomLevel((z) => Math.max(z / 1.2, 0.2)),
     []
   );
   /**
@@ -222,10 +231,13 @@ const SampleGraph = ({
               </div>
             )}
             <div
-              className="relative w-full border border-border rounded overflow-hidden"
+              className="relative mx-auto border border-border rounded overflow-hidden"
               style={{ maxWidth, height }}
             >
-              <div className="w-full h-full">
+              <div
+                className="w-full h-full"
+                style={{ transform: `scale(${zoomLevel})`, transformOrigin: "center" }}
+              >
                 <ErrorBoundary>
                   <Graphviz
                     dot={dot}
@@ -233,6 +245,14 @@ const SampleGraph = ({
                     style={{ width: "100%", height: "100%" }}
                   />
                 </ErrorBoundary>
+              </div>
+              <div className="absolute bottom-2 right-2 flex flex-col gap-1">
+                <Button size="icon" variant="secondary" type="button" onClick={handleZoomIn}>
+                  +
+                </Button>
+                <Button size="icon" variant="secondary" type="button" onClick={handleZoomOut}>
+                  -
+                </Button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add zoom state and handlers in `SampleGraph.jsx`
- center the Graphviz viewer inside the card
- add zoom in/out buttons overlaying the viewer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68756234c238832eb6979f16e31dc86e