### PR TITLE
Improve caching logic and timeline slider

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,14 +22,12 @@ export default function App() {
   const dateOptions = useMemo(() => {
     const dates = [];
     const now = new Date();
-    for (let i = 0; i < 8; i++) {
-      const monthsAgo = Math.floor(Math.random() * 60);
+    for (let i = 11; i >= 0; i--) {
       const d = new Date(now);
       d.setDate(1);
-      d.setMonth(now.getMonth() - monthsAgo);
+      d.setMonth(now.getMonth() - i);
       dates.push(d);
     }
-    dates.sort((a, b) => a - b);
     return dates;
   }, []);
 
@@ -493,7 +491,7 @@ export default function App() {
                 <div
                   key={i}
                   style={{ left: `${(i / (dateOptions.length - 1)) * 100}%` }}
-                  className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 size-2 rounded-full bg-border"
+                  className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 w-px h-full bg-border/50 pointer-events-none"
                 />
               ))}
             </div>

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -13,16 +13,20 @@ import { Button } from "@/components/ui/button";
 import { RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
 import { API_BASE } from "@/lib/api";
 
-const getCookie = (name) => {
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop().split(";").shift();
-  return null;
+const getCache = (key) => {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
 };
 
-const setCookie = (name, value, days = 1) => {
-  const expires = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toUTCString();
-  document.cookie = `${name}=${value}; expires=${expires}; path=/`;
+const setCache = (key, value) => {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // ignore write errors
+  }
 };
 
 /**
@@ -270,11 +274,11 @@ const SampleGraph = ({
     try {
       setLoading(true);
 
-      const cookieData = getCookie(`chain_${domain}`);
-      if (cookieData) {
+      const cached = getCache(`chain_${domain}`);
+      if (cached) {
         try {
-          json = JSON.parse(cookieData);
-          source = "cookie";
+          json = JSON.parse(cached);
+          source = "cache";
         } catch {
           json = null;
         }
@@ -290,7 +294,7 @@ const SampleGraph = ({
         }
         const res = await fetch(url);
         json = await res.json();
-        setCookie(`chain_${domain}`, JSON.stringify(json));
+        setCache(`chain_${domain}`, JSON.stringify(json));
       }
 
       setDot(buildDot(json));


### PR DESCRIPTION
## Summary
- persist graph data in `localStorage` instead of cookies
- report when cached data is used
- show last 12 months on timeline slider
- style slider notches to blend with the track

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d095745c4832ebb4ab81a26a1cbb1