### PR TITLE
Fix auto reload triggered by chain cache updates

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,7 +35,9 @@ app.add_middleware(
 DATA_FILE_PATH = os.path.join(os.path.dirname(__file__), "data.txt")
 # Store logs outside the project directory to avoid triggering frontend hot reloads
 LOG_FILE_PATH = os.path.join(tempfile.gettempdir(), "dnscap_chain_logs.txt")
-CACHE_FILE_PATH = os.path.join(os.path.dirname(__file__), "chain_cache.txt")
+# Cache data should also be stored outside the project directory to prevent
+# the frontend dev server from reloading when new domains are analyzed.
+CACHE_FILE_PATH = os.path.join(tempfile.gettempdir(), "dnscap_chain_cache.txt")
 data = []
 next_user_id = 1
 


### PR DESCRIPTION
## Summary
- ensure `chain_cache.txt` writes do not trigger Vite reloads

## Testing
- `python -m py_compile main.py`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d21f7f02c832e8994997777183a83