### PR TITLE
Fix parent-child node behavior

### DIFF
--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -313,7 +313,7 @@ const SampleGraph = ({
       nodes.push({
         id: kskId,
         type: 'record',
-        parentNode: groupId,
+        parentId: groupId,
         extent: 'parent',
         draggable: true,
         data: { label: 'KSK', tooltip: kskTooltip },
@@ -332,7 +332,7 @@ const SampleGraph = ({
         nodes.push({
           id: zskId,
           type: 'record',
-          parentNode: groupId,
+          parentId: groupId,
           extent: 'parent',
           draggable: true,
           data: { label: 'ZSK', tooltip: zskTooltip },
@@ -351,7 +351,7 @@ const SampleGraph = ({
         nodes.push({
           id: dsId,
           type: 'record',
-          parentNode: groupId,
+          parentId: groupId,
           extent: 'parent',
           draggable: true,
           data: { label: 'DS', tooltip: dsTooltip },
@@ -391,16 +391,6 @@ const SampleGraph = ({
 
       const { width: gw, height: gh } = g.graph();
 
-      nodes.forEach((node) => {
-        const { x, y } = g.node(node.id);
-        layoutedNodes.push({
-          ...node,
-          position: { x: x - nodeWidth / 2, y: y - nodeHeight / 2 + currentY },
-          sourcePosition: 'bottom',
-          targetPosition: 'top',
-        });
-      });
-
       const groupNode = groupNodes[idx];
       layoutedNodes.push({
         ...groupNode,
@@ -409,6 +399,16 @@ const SampleGraph = ({
         data: groupNode.data,
         width: gw + nodeWidth * 2,
         height: gh + nodeGap,
+      });
+
+      nodes.forEach((node) => {
+        const { x, y } = g.node(node.id);
+        layoutedNodes.push({
+          ...node,
+          position: { x: x - nodeWidth / 2, y: y - nodeHeight / 2 + currentY },
+          sourcePosition: 'bottom',
+          targetPosition: 'top',
+        });
       });
 
       currentY += gh + groupGap;


### PR DESCRIPTION
## Summary
- use `parentId` option for child nodes
- add group nodes before children so they move together

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f34b20fc4832ebe291a6c2ff1a103