### PR TITLE
Improve React Flow node visuals

### DIFF
--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -284,8 +284,8 @@ const SampleGraph = ({
   const buildFlow = useCallback((data) => {
     if (!data || !Array.isArray(data.levels)) return { nodes: [], edges: [] };
 
-    const nodeWidth = 150;
-    const nodeHeight = 50;
+    const nodeWidth = 180;
+    const nodeHeight = 60;
     const nodeGap = 60;
     const groupGap = 120;
 
@@ -324,8 +324,8 @@ const SampleGraph = ({
         parentId: groupId,
         extent: 'parent',
         draggable: true,
-        data: { label: 'KSK', tooltip: kskTooltip },
-        style: { background: '#ffcccc', width: nodeWidth },
+        data: { label: 'KSK', tooltip: kskTooltip, bg: '#ffcccc' },
+        style: { width: nodeWidth },
       });
 
       const zskRecords = (level.records?.dnskey_records || []).filter((r) => r.is_zsk);
@@ -343,8 +343,8 @@ const SampleGraph = ({
           parentId: groupId,
           extent: 'parent',
           draggable: true,
-          data: { label: 'ZSK', tooltip: zskTooltip },
-          style: { background: '#ffdddd', width: nodeWidth },
+          data: { label: 'ZSK', tooltip: zskTooltip, bg: '#ffdddd' },
+          style: { width: nodeWidth },
         });
         edges.push({ id: `${kskId}-${zskId}`, source: kskId, target: zskId, label: 'signs' });
       }
@@ -362,8 +362,8 @@ const SampleGraph = ({
           parentId: groupId,
           extent: 'parent',
           draggable: true,
-          data: { label: 'DS', tooltip: dsTooltip },
-          style: { background: '#ccccff', width: nodeWidth },
+          data: { label: 'DS', tooltip: dsTooltip, bg: '#ccccff' },
+          style: { width: nodeWidth },
         });
         edges.push({ id: `zsk_${idx}_0-${dsId}`, source: firstZskId, target: dsId, label: 'delegates' });
         crossEdges.push({

--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
 export default function GroupNode({ data }) {
-  const tooltipText = data.tooltip ? `${data.label}\n${data.tooltip}` : data.label;
+  // If tooltip text already includes the label don't prepend it again
+  const tooltipText = data.tooltip || data.label;
 
   return (
     <Tooltip>

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -8,7 +8,10 @@ export default function RecordNode({ data }) {
       <Handle type="target" position={Position.Top} />
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="px-2 py-1 rounded border bg-background text-foreground text-xs">
+          <div
+            className="px-2 py-1 rounded border text-xs transition-all duration-200 hover:ring-2 hover:ring-primary"
+            style={{ backgroundColor: data.bg || "var(--color-background)" }}
+          >
             {data.label}
           </div>
         </TooltipTrigger>


### PR DESCRIPTION
## Summary
- avoid duplicate zone labels in group node tooltips
- color record nodes internally, enlarge them, and add hover effects
- increase flow node dimensions to fit the larger child nodes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6880ba329f74832e9bd18cdab953e7b4