### PR TITLE
Update ReactFlow node sizes and relation labels

### DIFF
--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -284,8 +284,8 @@ const SampleGraph = ({
   const buildFlow = useCallback((data) => {
     if (!data || !Array.isArray(data.levels)) return { nodes: [], edges: [] };
 
-    const nodeWidth = 180;
-    const nodeHeight = 60;
+    const nodeWidth = 220;
+    const nodeHeight = 80;
     const nodeGap = 60;
     const groupGap = 120;
 
@@ -365,7 +365,7 @@ const SampleGraph = ({
           data: { label: 'DS', tooltip: dsTooltip, bg: '#ccccff' },
           style: { width: nodeWidth },
         });
-        edges.push({ id: `zsk_${idx}_0-${dsId}`, source: firstZskId, target: dsId, label: 'delegates' });
+        edges.push({ id: `zsk_${idx}_0-${dsId}`, source: firstZskId, target: dsId, label: 'signs' });
         crossEdges.push({
           id: `${dsId}-ksk_${idx + 1}`,
           source: dsId,

--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -8,7 +8,7 @@ export default function GroupNode({ data }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div className="w-full h-full bg-transparent rounded border p-2" />
+        <div className="w-full h-full bg-transparent rounded border p-2 transition-all duration-200 hover:ring-2 hover:ring-primary" />
       </TooltipTrigger>
       {tooltipText && (
         <TooltipContent className="whitespace-pre">{tooltipText}</TooltipContent>

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -9,7 +9,7 @@ export default function RecordNode({ data }) {
       <Tooltip>
         <TooltipTrigger asChild>
           <div
-            className="px-2 py-1 rounded border text-xs transition-all duration-200 hover:ring-2 hover:ring-primary"
+            className="px-4 py-2 rounded border text-sm transition-all duration-200 hover:ring-2 hover:ring-primary"
             style={{ backgroundColor: data.bg || "var(--color-background)" }}
           >
             {data.label}


### PR DESCRIPTION
## Summary
- enlarge child nodes
- give group nodes a hover ring
- correct DS→ZSK edges to use `signs` label

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880c0ffd610832e9965e04001626ad8