### PR TITLE
Refine broken chain visualization

### DIFF
--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -5,10 +5,14 @@ export default function GroupNode({ data }) {
   // If tooltip text already includes the label don't prepend it again
   const tooltipText = data.tooltip || data.label;
 
+  const ringColor = data.ringColor || 'var(--color-primary)';
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div className="w-full h-full bg-transparent rounded border p-2 transition-all duration-200 hover:ring-2 hover:ring-primary" />
+        <div
+          className="w-full h-full bg-transparent rounded border p-2 transition-all duration-200 hover:ring-2"
+          style={{ '--tw-ring-color': ringColor }}
+        />
       </TooltipTrigger>
       {tooltipText && (
         <TooltipContent className="whitespace-pre">{tooltipText}</TooltipContent>

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -3,14 +3,18 @@ import { Handle, Position } from '@xyflow/react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
 export default function RecordNode({ data }) {
+  const ringColor = data.ringColor || 'var(--color-primary)';
   return (
     <div className="relative flex flex-col items-center">
       <Handle type="target" position={Position.Top} />
       <Tooltip>
         <TooltipTrigger asChild>
           <div
-            className="px-4 py-2 rounded border text-sm transition-all duration-200 hover:ring-2 hover:ring-primary"
-            style={{ backgroundColor: data.bg || "var(--color-background)" }}
+            className="px-4 py-2 rounded border text-sm transition-all duration-200 hover:ring-2"
+            style={{
+              backgroundColor: data.bg || 'var(--color-background)',
+              '--tw-ring-color': ringColor,
+            }}
           >
             {data.label}
           </div>


### PR DESCRIPTION
## Summary
- show `NO DS` label instead of removing DS nodes
- add ringColor for missing DS/ZSK/KSK and group nodes
- mark missing delegation/signing edges with red color and updated labels

## Testing
- `npm run lint`
- `python3 test.py example.com`


------
https://chatgpt.com/codex/tasks/task_e_6881b9581e64832ea0cd0aad48568fc9