### PR TITLE
feat: add pinnable tooltip component

### DIFF
--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import {
+  PinnedTooltip,
+  PinnedTooltipTrigger,
+  PinnedTooltipContent,
+} from '@/components/ui/tooltip';
 
 export default function GroupNode({ data }) {
   // If tooltip text already includes the label don't prepend it again
@@ -7,16 +11,18 @@ export default function GroupNode({ data }) {
 
   const ringColor = data.ringColor || 'var(--color-primary)';
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
+    <PinnedTooltip>
+      <PinnedTooltipTrigger asChild>
         <div
           className="w-full h-full bg-transparent rounded border p-2 transition-all duration-200 hover:ring-2"
           style={{ '--tw-ring-color': ringColor }}
         />
-      </TooltipTrigger>
+      </PinnedTooltipTrigger>
       {tooltipText && (
-        <TooltipContent className="whitespace-pre">{tooltipText}</TooltipContent>
+        <PinnedTooltipContent className="whitespace-pre">
+          {tooltipText}
+        </PinnedTooltipContent>
       )}
-    </Tooltip>
+    </PinnedTooltip>
   );
 }

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import { Handle, Position } from '@xyflow/react';
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import {
+  PinnedTooltip,
+  PinnedTooltipTrigger,
+  PinnedTooltipContent,
+} from '@/components/ui/tooltip';
 
 export default function RecordNode({ data }) {
   const ringColor = data.ringColor || 'var(--color-primary)';
   return (
     <div className="relative flex flex-col items-center">
       <Handle type="target" position={Position.Top} />
-      <Tooltip>
-        <TooltipTrigger asChild>
+      <PinnedTooltip>
+        <PinnedTooltipTrigger asChild>
           <div
             className="px-4 py-2 rounded border text-sm transition-all duration-200 hover:ring-2"
             style={{
@@ -18,13 +22,13 @@ export default function RecordNode({ data }) {
           >
             {data.label}
           </div>
-        </TooltipTrigger>
+        </PinnedTooltipTrigger>
         {data.tooltip && (
-          <TooltipContent className="whitespace-pre">
+          <PinnedTooltipContent className="whitespace-pre">
             {data.tooltip}
-          </TooltipContent>
+          </PinnedTooltipContent>
         )}
-      </Tooltip>
+      </PinnedTooltip>
       <Handle type="source" position={Position.Bottom} />
     </div>
   );

--- a/src/components/ui/tooltip.jsx
+++ b/src/components/ui/tooltip.jsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
+import { Pin, PinOff } from "lucide-react"
+
 import { cn } from "@/lib/utils"
 
 function TooltipProvider({
@@ -51,3 +53,104 @@ function TooltipContent({
 }
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+
+// ---------------------------------------------------------------------------
+// Pinned tooltip
+// ---------------------------------------------------------------------------
+
+const PinnedTooltipContext = React.createContext({
+  pinned: false,
+  togglePinned: () => {},
+})
+
+function PinnedTooltip({ isPinned, onUnpin, children, ...props }) {
+  const [pinned, setPinned] = React.useState(isPinned ?? false)
+  const [open, setOpen] = React.useState(false)
+
+  React.useEffect(() => {
+    if (isPinned !== undefined) {
+      setPinned(isPinned)
+    }
+  }, [isPinned])
+
+  React.useEffect(() => {
+    if (!pinned && onUnpin) {
+      onUnpin()
+    }
+  }, [pinned, onUnpin])
+
+  const togglePinned = React.useCallback(() => {
+    setPinned((p) => !p)
+  }, [])
+
+  const handleOpenChange = React.useCallback(
+    (value) => {
+      if (!pinned) {
+        setOpen(value)
+      }
+    },
+    [pinned]
+  )
+
+  return (
+    <TooltipProvider>
+      <PinnedTooltipContext.Provider value={{ pinned, togglePinned }}>
+        <TooltipPrimitive.Root
+          data-slot="pinned-tooltip"
+          open={pinned || open}
+          onOpenChange={handleOpenChange}
+          {...props}
+        >
+          {children}
+        </TooltipPrimitive.Root>
+      </PinnedTooltipContext.Provider>
+    </TooltipProvider>
+  )
+}
+
+const PinnedTooltipTrigger = TooltipTrigger
+
+function PinnedTooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}) {
+  const { pinned, togglePinned } = React.useContext(PinnedTooltipContext)
+  const Icon = pinned ? PinOff : Pin
+
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="pinned-tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        <div className="flex items-start gap-2">
+          <div className="flex-1">{children}</div>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              togglePinned()
+            }}
+            className="text-primary-foreground/80 hover:text-primary-foreground"
+          >
+            <Icon className="size-3" />
+          </button>
+        </div>
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export {
+  PinnedTooltip,
+  PinnedTooltipTrigger,
+  PinnedTooltipContent,
+}


### PR DESCRIPTION
## Summary
- add `PinnedTooltip` wrapper with internal pin state and pin/unpin icon
- use `PinnedTooltip` in ReactFlow's `GroupNode` and `RecordNode` so multiple tooltips can stay open

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688efbc92a70832eabb901ab3684e252