### PR TITLE
feat: add export and resize for reactflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "graphviz-react": "^1.2.5",
         "liquid-glass-react": "^1.1.1",
         "lucide-react": "^0.511.0",
+        "re-resizable": "^6.11.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-force-graph-2d": "^1.27.1",
@@ -4684,6 +4685,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "graphviz-react": "^1.2.5",
     "liquid-glass-react": "^1.1.1",
     "lucide-react": "^0.511.0",
+    "re-resizable": "^6.11.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-force-graph-2d": "^1.27.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import SampleGraph from "./SampleGraph.jsx";
+import { ReactFlowProvider } from "@xyflow/react";
 
 const getCache = (key) => {
   try {
@@ -534,15 +535,17 @@ export default function App() {
               ))}
             </div>
           </div>
-          <SampleGraph
-            domain={currentDomain}
-            refreshTrigger={refreshTrigger}
-            theme={theme}
-            viewMode={viewMode}
-            onRefresh={handleRefresh}
-            userId={userId}
-            selectedDate={selectedDate.toISOString().slice(0, 7)}
-          />
+          <ReactFlowProvider>
+            <SampleGraph
+              domain={currentDomain}
+              refreshTrigger={refreshTrigger}
+              theme={theme}
+              viewMode={viewMode}
+              onRefresh={handleRefresh}
+              userId={userId}
+              selectedDate={selectedDate.toISOString().slice(0, 7)}
+            />
+          </ReactFlowProvider>
         </div>
       </main>
       <footer className="border-t border-border bg-card text-card-foreground p-4 text-sm">

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -11,6 +11,11 @@ export default function RecordNode({ data }) {
   return (
     <div className="relative flex flex-col items-center">
       <Handle type="target" position={Position.Top} />
+      {data.levelName && (
+        <div className="text-xs text-muted-foreground mb-1">
+          {data.levelName}
+        </div>
+      )}
       <PinnedTooltip>
         <PinnedTooltipTrigger asChild>
           <div


### PR DESCRIPTION
## Summary
- add JSON/SVG export handlers and buttons for ReactFlow diagrams
- wrap ReactFlow view in a resizable container and shrink node spacing
- show DNS level labels above record nodes and provide ReactFlow context

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f1afc8d14832eb1734529cabdac78