### PR TITLE
Render key metadata in ReactFlow nodes with PNG export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "d3-zoom": "^3.0.0",
         "dagre": "^0.8.5",
         "graphviz-react": "^1.2.5",
+        "html-to-image": "^1.11.13",
         "liquid-glass-react": "^1.1.1",
         "lucide-react": "^0.511.0",
         "re-resizable": "^6.11.2",
@@ -3877,6 +3878,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "d3-zoom": "^3.0.0",
     "dagre": "^0.8.5",
     "graphviz-react": "^1.2.5",
+    "html-to-image": "^1.11.13",
     "liquid-glass-react": "^1.1.1",
     "lucide-react": "^0.511.0",
     "re-resizable": "^6.11.2",

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -12,20 +12,27 @@ export default function RecordNode({ data }) {
     <div className="relative flex flex-col items-center">
       <Handle type="target" position={Position.Top} />
       {data.levelName && (
-        <div className="text-xs text-muted-foreground mb-1">
+        <div className="text-sm text-muted-foreground mb-2">
           {data.levelName}
         </div>
       )}
       <PinnedTooltip>
         <PinnedTooltipTrigger asChild>
           <div
-            className="px-4 py-2 rounded border text-sm transition-all duration-200 hover:ring-2"
+            className="px-5 py-3 rounded border text-base transition-all duration-200 hover:ring-2 text-center"
             style={{
               backgroundColor: data.bg || 'var(--color-background)',
               '--tw-ring-color': ringColor,
             }}
           >
-            {data.label}
+            <div>{data.label}</div>
+            {(data.flags || data.size) && (
+              <div className="mt-1 text-xs">
+                {data.flags && <>Flags: {data.flags}</>}
+                {data.flags && data.size && ' | '}
+                {data.size && <>Size: {data.size}</>}
+              </div>
+            )}
           </div>
         </PinnedTooltipTrigger>
         {data.tooltip && (


### PR DESCRIPTION
## Summary
- Revert Graphviz node labels to simple KSK/ZSK so metadata shows only in ReactFlow
- Add html-to-image and export ReactFlow view as a downloadable PNG screenshot
- Display flags and key size directly inside ReactFlow nodes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f76f1ccbc832e8e25b99677c011a1