### PR TITLE
refactor: extract ReactFlow graph into its own component

### DIFF
--- a/src/ReactFlowGraph.jsx
+++ b/src/ReactFlowGraph.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { ReactFlow, Background, Controls } from "@xyflow/react";
+import { Resizable } from "re-resizable";
+import ErrorBoundary from "@/components/ErrorBoundary.jsx";
+import "@xyflow/react/dist/style.css";
+
+/**
+ * Renders a ReactFlow graph with resizing support.
+ *
+ * @param {object} props
+ * @param {Array} props.nodes - ReactFlow nodes
+ * @param {Array} props.edges - ReactFlow edges
+ * @param {Function} props.onNodesChange - Handler for node changes
+ * @param {Function} props.onEdgesChange - Handler for edge changes
+ * @param {object} props.nodeTypes - Custom node types
+ * @param {{width:number|string, height:number|string}} props.rfSize - Current size of the graph
+ * @param {Function} props.setRfSize - Setter for graph size
+ * @param {React.MutableRefObject} props.graphContainerRef - Ref to the container element
+ */
+const ReactFlowGraph = ({
+  nodes,
+  edges,
+  onNodesChange,
+  onEdgesChange,
+  nodeTypes,
+  rfSize,
+  setRfSize,
+  graphContainerRef,
+}) => {
+  return (
+    <Resizable
+      size={rfSize}
+      onResizeStop={(e, dir, ref, d) =>
+        setRfSize({
+          width: rfSize.width + d.width,
+          height: rfSize.height + d.height,
+        })
+      }
+      className="relative border border-border rounded overflow-hidden mx-auto"
+    >
+      <div className="w-full h-full" ref={graphContainerRef}>
+        <ErrorBoundary>
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            nodeTypes={nodeTypes}
+            fitView
+            style={{ width: "100%", height: "100%" }}
+          >
+            <Background />
+            <Controls />
+          </ReactFlow>
+        </ErrorBoundary>
+      </div>
+    </Resizable>
+  );
+};
+
+export default ReactFlowGraph;
+

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -8,9 +8,6 @@ import React, {
 import Graphviz from "graphviz-react";
 import { graphviz } from "d3-graphviz";
 import {
-  ReactFlow,
-  Background,
-  Controls,
   useNodesState,
   useEdgesState,
   useReactFlow,
@@ -18,14 +15,13 @@ import {
   getViewportForBounds,
 } from "@xyflow/react";
 import { toPng } from "html-to-image";
-import { Resizable } from "re-resizable";
-import "@xyflow/react/dist/style.css";
 import dagre from "dagre";
 import ErrorBoundary from "@/components/ErrorBoundary.jsx";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import RecordNode from "@/components/nodes/RecordNode.jsx";
 import GroupNode from "@/components/nodes/GroupNode.jsx";
+import ReactFlowGraph from "./ReactFlowGraph.jsx";
 
 import { Maximize, RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
 
@@ -795,33 +791,16 @@ const SampleGraph = ({
                 </div>
               </div>
             ) : (
-              <Resizable
-                size={rfSize}
-                onResizeStop={(e, dir, ref, d) =>
-                  setRfSize({
-                    width: rfSize.width + d.width,
-                    height: rfSize.height + d.height,
-                  })
-                }
-                className="relative border border-border rounded overflow-hidden mx-auto"
-              >
-                <div className="w-full h-full" ref={graphContainerRef}>
-                  <ErrorBoundary>
-                    <ReactFlow
-                      nodes={nodes}
-                      edges={edges}
-                      onNodesChange={onNodesChange}
-                      onEdgesChange={onEdgesChange}
-                      nodeTypes={nodeTypes}
-                      fitView
-                      style={{ width: "100%", height: "100%" }}
-                    >
-                      <Background />
-                      <Controls />
-                    </ReactFlow>
-                  </ErrorBoundary>
-                </div>
-              </Resizable>
+              <ReactFlowGraph
+                nodes={nodes}
+                edges={edges}
+                onNodesChange={onNodesChange}
+                onEdgesChange={onEdgesChange}
+                nodeTypes={nodeTypes}
+                rfSize={rfSize}
+                setRfSize={setRfSize}
+                graphContainerRef={graphContainerRef}
+              />
             )}
           </div>
         </CardContent>


### PR DESCRIPTION
## Summary
- extract ReactFlow graph into `ReactFlowGraph` component
- adjust `SampleGraph` to consume the new component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68988037c074832ebf29ee1866f1ed7c