### PR TITLE
refactor: centralize ReactFlow logic

### DIFF
--- a/src/ReactFlow.jsx
+++ b/src/ReactFlow.jsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { ReactFlow, Background, Controls } from "@xyflow/react";
+import {
+  ReactFlow as ReactFlowBase,
+  Background,
+  Controls,
+} from "@xyflow/react";
 import { Resizable } from "re-resizable";
 import ErrorBoundary from "@/components/ErrorBoundary.jsx";
 import "@xyflow/react/dist/style.css";
@@ -17,7 +21,7 @@ import "@xyflow/react/dist/style.css";
  * @param {Function} props.setRfSize - Setter for graph size
  * @param {React.MutableRefObject} props.graphContainerRef - Ref to the container element
  */
-const ReactFlowGraph = ({
+const ReactFlow = ({
   nodes,
   edges,
   onNodesChange,
@@ -40,7 +44,7 @@ const ReactFlowGraph = ({
     >
       <div className="w-full h-full" ref={graphContainerRef}>
         <ErrorBoundary>
-          <ReactFlow
+          <ReactFlowBase
             nodes={nodes}
             edges={edges}
             onNodesChange={onNodesChange}
@@ -51,12 +55,12 @@ const ReactFlowGraph = ({
           >
             <Background />
             <Controls />
-          </ReactFlow>
+          </ReactFlowBase>
         </ErrorBoundary>
       </div>
     </Resizable>
   );
 };
 
-export default ReactFlowGraph;
+export default ReactFlow;
 

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -21,7 +21,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import RecordNode from "@/components/nodes/RecordNode.jsx";
 import GroupNode from "@/components/nodes/GroupNode.jsx";
-import ReactFlowGraph from "./ReactFlowGraph.jsx";
+import ReactFlow from "./ReactFlow.jsx";
 
 import { Maximize, RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
 
@@ -791,7 +791,7 @@ const SampleGraph = ({
                 </div>
               </div>
             ) : (
-              <ReactFlowGraph
+              <ReactFlow
                 nodes={nodes}
                 edges={edges}
                 onNodesChange={onNodesChange}


### PR DESCRIPTION
## Summary
- rename ReactFlowGraph to ReactFlow and centralize graph rendering
- update SampleGraph to use new ReactFlow component

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898b2275120832eb91ec3e46cc40af8