### PR TITLE
feat: add domain header to flow nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "react-dom": "^19.1.0",
         "react-force-graph-2d": "^1.27.1",
         "tailwind-merge": "^3.3.0",
-        "tailwindcss": "^4.1.8"
+        "tailwindcss": "^4.1.8",
+        "tldts": "^6.1.86"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -5090,6 +5091,24 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "react-dom": "^19.1.0",
     "react-force-graph-2d": "^1.27.1",
     "tailwind-merge": "^3.3.0",
-    "tailwindcss": "^4.1.8"
+    "tailwindcss": "^4.1.8",
+    "tldts": "^6.1.86"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -1,22 +1,36 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   PinnedTooltip,
   PinnedTooltipTrigger,
   PinnedTooltipContent,
 } from '@/components/ui/tooltip';
+import { computeDomain, HEADER_STYLE } from '@/lib/domain';
 
-export default function GroupNode({ data }) {
+export default function GroupNode({ data, id }) {
   // If tooltip text already includes the label don't prepend it again
   const tooltipText = data.tooltip || data.label;
 
   const ringColor = data.ringColor || 'var(--color-primary)';
+  const { full: domainFull, truncated: domainShort } = useMemo(
+    () => computeDomain(data, id),
+    [data, id]
+  );
   return (
     <PinnedTooltip>
       <PinnedTooltipTrigger asChild>
-        <div
-          className="w-full h-full bg-transparent rounded border p-2 transition-all duration-200 hover:ring-2"
-          style={{ '--tw-ring-color': ringColor }}
-        />
+        <div className="relative w-full h-full">
+          <div
+            className="absolute top-0 left-0 right-0 z-0 rounded-t-2xl bg-gradient-to-r from-[#F472B6] via-[#E879F9] to-[#C084FC] text-white text-xs font-bold tracking-[0.04em] pl-2 pt-1.5 select-none"
+            style={{ height: HEADER_STYLE.height }}
+            title={domainFull}
+          >
+            {domainShort}
+          </div>
+          <div
+            className="absolute left-0 right-0 bottom-0 z-10 bg-transparent rounded-2xl border p-2 transition-all duration-200 hover:ring-2"
+            style={{ top: HEADER_STYLE.visibleHeight, '--tw-ring-color': ringColor }}
+          />
+        </div>
       </PinnedTooltipTrigger>
       {tooltipText && (
         <PinnedTooltipContent className="whitespace-pre">

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -1,13 +1,18 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Handle, Position } from "@xyflow/react";
 import {
   PinnedTooltip,
   PinnedTooltipTrigger,
   PinnedTooltipContent,
 } from "@/components/ui/tooltip";
+import { computeDomain, HEADER_STYLE } from "@/lib/domain";
 
-export default function RecordNode({ data }) {
+export default function RecordNode({ data, id }) {
   const ringColor = data.ringColor || "var(--color-primary)";
+  const { full: domainFull, truncated: domainShort } = useMemo(
+    () => computeDomain(data, id),
+    [data, id]
+  );
   return (
     <div className="relative flex flex-col items-center">
       <Handle type="target" position={Position.Top} />
@@ -18,21 +23,31 @@ export default function RecordNode({ data }) {
       )}
       <PinnedTooltip>
         <PinnedTooltipTrigger asChild>
-          <div
-            className="px-5 py-3 rounded border text-base transition-all duration-200 hover:ring-2 text-center"
-            style={{
-              backgroundColor: data.bg || "var(--color-background)",
-              "--tw-ring-color": ringColor,
-            }}
-          >
-            <div>{data.label}</div>
-            {(data.flags || data.size) && (
-              <div className="mt-1 text-xs">
-                {data.flags && <>Flags: {data.flags}</>}
-                {data.flags && data.size && " | "}
-                {data.size && <>Size: {data.size}</>}
-              </div>
-            )}
+          <div className="relative">
+            <div
+              className="absolute top-0 left-0 right-0 z-0 rounded-t-2xl bg-gradient-to-r from-[#F472B6] via-[#E879F9] to-[#C084FC] text-white text-xs font-bold tracking-[0.04em] pl-2 pt-1.5 select-none"
+              style={{ height: HEADER_STYLE.height }}
+              title={domainFull}
+            >
+              {domainShort}
+            </div>
+            <div
+              className="relative z-10 px-5 py-3 rounded-2xl border text-base transition-all duration-200 hover:ring-2 text-center"
+              style={{
+                marginTop: HEADER_STYLE.visibleHeight,
+                backgroundColor: data.bg || "var(--color-background)",
+                "--tw-ring-color": ringColor,
+              }}
+            >
+              <div>{data.label}</div>
+              {(data.flags || data.size) && (
+                <div className="mt-1 text-xs">
+                  {data.flags && <>Flags: {data.flags}</>}
+                  {data.flags && data.size && " | "}
+                  {data.size && <>Size: {data.size}</>}
+                </div>
+              )}
+            </div>
           </div>
         </PinnedTooltipTrigger>
         {data.tooltip && (

--- a/src/lib/domain.js
+++ b/src/lib/domain.js
@@ -1,0 +1,29 @@
+import { getDomain } from 'tldts';
+
+const MAX_LENGTH = 26;
+const HEADER_HEIGHT = 32; // px
+const UNDERLAP = 10; // px overlapped by card body
+
+export const HEADER_STYLE = {
+  height: HEADER_HEIGHT,
+  visibleHeight: HEADER_HEIGHT - UNDERLAP,
+};
+
+export function computeDomain(data = {}, id = '') {
+  let raw = (data.domain ?? data.label ?? id ?? '').toString().toLowerCase().trim();
+  if (raw.endsWith('.')) {
+    raw = raw.slice(0, -1);
+  }
+  let full = getDomain(raw, { allowPrivateDomains: true }) || raw;
+  if (!full) {
+    full = '(no domain)';
+  }
+  const truncated = truncateMiddle(full, MAX_LENGTH);
+  return { full, truncated };
+}
+
+function truncateMiddle(str, max) {
+  if (str.length <= max) return str;
+  const half = Math.floor((max - 1) / 2);
+  return str.slice(0, half) + '…' + str.slice(str.length - half);
+}


### PR DESCRIPTION
## Summary
- add domain header to flow nodes with purple gradient and underlap
- normalize and truncate domains for display
- include tldts dependency for domain parsing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899c4fabe14832eb395edde1bb62555