### PR TITLE
Add color flow graph with animated background

### DIFF
--- a/src/ColorFlow.jsx
+++ b/src/ColorFlow.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import {
+  ReactFlow as ReactFlowBase,
+  Background,
+  Controls,
+} from "@xyflow/react";
+import { Resizable } from "re-resizable";
+import ErrorBoundary from "@/components/ErrorBoundary.jsx";
+import "@xyflow/react/dist/style.css";
+import "./colorful-bg.css";
+
+/**
+ * ReactFlow graph with animated background.
+ */
+const ColorFlow = ({
+  nodes,
+  edges,
+  onNodesChange,
+  onEdgesChange,
+  nodeTypes,
+  rfSize,
+  setRfSize,
+  graphContainerRef,
+}) => {
+  return (
+    <Resizable
+      size={rfSize}
+      onResizeStop={(e, dir, ref, d) =>
+        setRfSize({
+          width: rfSize.width + d.width,
+          height: rfSize.height + d.height,
+        })
+      }
+      className="relative border border-border rounded overflow-hidden mx-auto"
+    >
+      <div className="w-full h-full colorful-background" ref={graphContainerRef}>
+        <ErrorBoundary>
+          <ReactFlowBase
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            nodeTypes={nodeTypes}
+            fitView
+            style={{ width: "100%", height: "100%", background: "transparent" }}
+          >
+            <Background />
+            <Controls />
+          </ReactFlowBase>
+        </ErrorBoundary>
+      </div>
+    </Resizable>
+  );
+};
+
+export default ColorFlow;

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -22,6 +22,8 @@ import { Button } from "@/components/ui/button";
 import RecordNode from "@/components/nodes/RecordNode.jsx";
 import GroupNode from "@/components/nodes/GroupNode.jsx";
 import ReactFlow from "./ReactFlow.jsx";
+import ColorFlow from "./ColorFlow.jsx";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 
 import { Maximize, RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
 
@@ -103,6 +105,13 @@ const SampleGraph = ({
     };
 
   const [rfSize, setRfSize] = useState({
+    width: parseSize(maxWidth, 896),
+    height: parseSize(height, 448),
+  });
+
+  const [colorGraphOpen, setColorGraphOpen] = useState(false);
+  const colorGraphContainerRef = useRef(null);
+  const [colorRfSize, setColorRfSize] = useState({
     width: parseSize(maxWidth, 896),
     height: parseSize(height, 448),
   });
@@ -857,6 +866,13 @@ const SampleGraph = ({
             >
               PNG
             </Button>
+            <Button
+              variant="secondary"
+              onClick={() => setColorGraphOpen(true)}
+              type="button"
+            >
+              Color
+            </Button>
           </>
         )}
         {viewMode === "graphviz" && (
@@ -880,6 +896,20 @@ const SampleGraph = ({
           </>
         )}
       </div>
+      <Dialog open={colorGraphOpen} onOpenChange={setColorGraphOpen}>
+        <DialogContent className="max-w-[90vw] w-[90vw] h-[80vh] p-0">
+          <ColorFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            nodeTypes={nodeTypes}
+            rfSize={colorRfSize}
+            setRfSize={setColorRfSize}
+            graphContainerRef={colorGraphContainerRef}
+          />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/src/colorful-bg.css
+++ b/src/colorful-bg.css
@@ -1,0 +1,11 @@
+.colorful-background {
+  background: linear-gradient(270deg, red, orange, yellow, blue, lightblue, red);
+  background-size: 1000% 1000%;
+  animation: paintbrush 20s ease infinite;
+}
+
+@keyframes paintbrush {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}


### PR DESCRIPTION
## Summary
- add Color button to open an alternate ReactFlow graph
- implement ColorFlow component with animated multicolor background
- include CSS animation blending red, orange, yellow, blue, and light blue

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899dcd88654832e8a68948d32b2a85c