### PR TITLE
feat: add liquid glass effect to ReactFlow nodes

### DIFF
--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import LiquidGlass from 'liquid-glass-react';
 import {
   PinnedTooltip,
   PinnedTooltipTrigger,
@@ -13,12 +14,13 @@ export default function GroupNode({ data }) {
   return (
     <PinnedTooltip>
       <PinnedTooltipTrigger asChild>
-        <div className="relative w-full h-full">
-          <div
-            className="absolute left-0 right-0 top-0 bottom-0 z-10 bg-transparent rounded-2xl border p-2 transition-all duration-200 hover:ring-2"
-            style={{ '--tw-ring-color': ringColor }}
-          />
-        </div>
+        <LiquidGlass
+          className="relative w-full h-full rounded-2xl border p-2 transition-all duration-200 hover:ring-2"
+          padding="0"
+          style={{ '--tw-ring-color': ringColor }}
+        >
+          <div className="w-full h-full" />
+        </LiquidGlass>
       </PinnedTooltipTrigger>
       {tooltipText && (
         <PinnedTooltipContent className="whitespace-pre">

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { Handle, Position } from "@xyflow/react";
+import LiquidGlass from "liquid-glass-react";
 import {
   PinnedTooltip,
   PinnedTooltipTrigger,
@@ -27,8 +28,10 @@ export default function RecordNode({ data }) {
             >
               {truncated}
             </div>
-            <div
+            <LiquidGlass
               className="relative z-10 px-5 py-3 rounded-2xl border text-base transition-all duration-200 hover:ring-2 text-center"
+              padding="0"
+              cornerRadius={24}
               style={{
                 marginTop: HEADER_STYLE.visibleHeight,
                 backgroundColor: data.bg || "var(--color-background)",
@@ -43,7 +46,7 @@ export default function RecordNode({ data }) {
                   {data.size && <>Size: {data.size}</>}
                 </div>
               )}
-            </div>
+            </LiquidGlass>
           </div>
         </PinnedTooltipTrigger>
         {data.tooltip && (


### PR DESCRIPTION
## Summary
- wrap RecordNode and GroupNode content with `liquid-glass-react` for Apple-inspired glass UI

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f5e1fd1c832e83abc0beaf830b0f