### PR TITLE
Remove color coding from React graph

### DIFF
--- a/src/ColorFlow.jsx
+++ b/src/ColorFlow.jsx
@@ -6,7 +6,6 @@ import {
 } from "@xyflow/react";
 import { Resizable } from "re-resizable";
 import ErrorBoundary from "@/components/ErrorBoundary.jsx";
-import NebulaBackground from "@/components/NebulaBackground.jsx";
 import "@xyflow/react/dist/style.css";
 
 /**
@@ -33,8 +32,7 @@ const ColorFlow = ({
       }
       className="relative border border-border rounded overflow-hidden mx-auto"
     >
-      <div className="w-full h-full relative" ref={graphContainerRef}>
-        <NebulaBackground />
+      <div className="w-full h-full" ref={graphContainerRef}>
         <ErrorBoundary>
           <ReactFlowBase
             nodes={nodes}
@@ -43,7 +41,7 @@ const ColorFlow = ({
             onEdgesChange={onEdgesChange}
             nodeTypes={nodeTypes}
             fitView
-            style={{ width: "100%", height: "100%", background: "transparent" }}
+            style={{ width: "100%", height: "100%", background: "white" }}
           >
             <Background />
             <Controls />

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -441,12 +441,6 @@ const SampleGraph = ({
       const zskRecords = (level.records?.dnskey_records || []).filter(
         (r) => r.is_zsk
       );
-      const kskRingColor =
-        !ksk || zskRecords.length === 0
-          ? "var(--color-destructive)"
-          : undefined;
-
-      const groupRingColor = kskRingColor;
       groupNodes.push({
         id: groupId,
         type: "dnsGroup",
@@ -456,7 +450,6 @@ const SampleGraph = ({
           tooltip: `${
             level.display_name || `Level ${idx}`
           }\n${securityTooltip}`,
-          ringColor: groupRingColor,
         },
         position: { x: 0, y: 0 },
       });
@@ -469,8 +462,6 @@ const SampleGraph = ({
         data: {
           label: ksk ? "KSK" : "NO KSK",
           tooltip: kskTooltip,
-          bg: "#ffcccc",
-          ringColor: kskRingColor,
           domain: level.display_name,
           flags: ksk?.flags,
           size: ksk?.key_size,
@@ -497,8 +488,6 @@ const SampleGraph = ({
           data: {
             label: zskRecord ? "ZSK" : "NO ZSK",
             tooltip: zskTooltip,
-            bg: "#ffdddd",
-            ringColor: zskRecord ? undefined : "var(--color-destructive)",
             domain: level.display_name,
             flags: zskRecord?.flags,
             size: zskRecord?.key_size,
@@ -536,8 +525,6 @@ const SampleGraph = ({
           data: {
             label: ds ? "DS" : "NO DS",
             tooltip: dsTooltip,
-            bg: "#ccccff",
-            ringColor: ds ? undefined : "var(--color-destructive)",
             domain: level.display_name,
           },
           style: { width: nodeWidth },
@@ -582,8 +569,6 @@ const SampleGraph = ({
             data: {
               label: type,
               tooltip,
-              bg: "#ccffcc",
-              ringColor: rec.signed ? undefined : "var(--color-destructive)",
               domain: level.display_name,
             },
             style: { width: nodeWidth },

--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -1,30 +1,13 @@
 import React from 'react';
-import {
-  PinnedTooltip,
-  PinnedTooltipTrigger,
-  PinnedTooltipContent,
-} from '@/components/ui/tooltip';
 
-export default function GroupNode({ data }) {
-  // If tooltip text already includes the label don't prepend it again
-  const tooltipText = data.tooltip || data.label;
-
-  const ringColor = data.ringColor || 'var(--color-primary)';
+export default function GroupNode() {
+  const ringColor = 'var(--color-primary)';
   return (
-    <PinnedTooltip>
-      <PinnedTooltipTrigger asChild>
-        <div className="relative w-full h-full">
-          <div
-            className="absolute left-0 right-0 top-0 bottom-0 z-10 bg-transparent rounded-2xl border p-2 transition-all duration-200 hover:ring-2"
-            style={{ '--tw-ring-color': ringColor }}
-          />
-        </div>
-      </PinnedTooltipTrigger>
-      {tooltipText && (
-        <PinnedTooltipContent className="whitespace-pre">
-          {tooltipText}
-        </PinnedTooltipContent>
-      )}
-    </PinnedTooltip>
+    <div className="relative w-full h-full">
+      <div
+        className="absolute left-0 right-0 top-0 bottom-0 z-10 bg-transparent rounded-2xl border p-2 ring-2"
+        style={{ '--tw-ring-color': ringColor }}
+      />
+    </div>
   );
 }

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -1,57 +1,43 @@
 import React, { useMemo } from "react";
 import { Handle, Position } from "@xyflow/react";
-import {
-  PinnedTooltip,
-  PinnedTooltipTrigger,
-  PinnedTooltipContent,
-} from "@/components/ui/tooltip";
 import { computeDomain, HEADER_STYLE } from "@/lib/domain";
 
 export default function RecordNode({ data }) {
-  const ringColor = data.ringColor || "var(--color-primary)";
+  const ringColor = "var(--color-primary)";
   const { full: domainFull, truncated } = useMemo(
     () => computeDomain(data),
     [data]
   );
-  const headerColor = "var(--color-primary)";
+  const headerColor = "transparent";
   return (
     <div className="relative flex flex-col items-center">
       <Handle type="target" position={Position.Top} />
-      <PinnedTooltip>
-        <PinnedTooltipTrigger asChild>
-          <div className="relative">
-            <div
-              className="absolute top-0 left-0 right-0 z-0 rounded-t-2xl text-white text-sm font-bold tracking-[0.04em] pl-2 pt-2 select-none"
-              style={{ height: HEADER_STYLE.height, backgroundColor: headerColor }}
-              title={domainFull}
-            >
-              {truncated}
+      <div className="relative">
+        <div
+          className="absolute top-0 left-0 right-0 z-0 rounded-t-2xl text-sm font-bold tracking-[0.04em] pl-2 pt-2 select-none"
+          style={{ height: HEADER_STYLE.height, backgroundColor: headerColor }}
+          title={domainFull}
+        >
+          {truncated}
+        </div>
+        <div
+          className="relative z-10 px-5 py-3 rounded-2xl border text-base ring-2 text-center"
+          style={{
+            marginTop: HEADER_STYLE.visibleHeight,
+            backgroundColor: "transparent",
+            "--tw-ring-color": ringColor,
+          }}
+        >
+          <div>{data.label}</div>
+          {(data.flags || data.size) && (
+            <div className="mt-1 text-xs">
+              {data.flags && <>Flags: {data.flags}</>}
+              {data.flags && data.size && " | "}
+              {data.size && <>Size: {data.size}</>}
             </div>
-            <div
-              className="relative z-10 px-5 py-3 rounded-2xl border text-base transition-all duration-200 hover:ring-2 text-center"
-              style={{
-                marginTop: HEADER_STYLE.visibleHeight,
-                backgroundColor: data.bg || "var(--color-background)",
-                "--tw-ring-color": ringColor,
-              }}
-            >
-              <div>{data.label}</div>
-              {(data.flags || data.size) && (
-                <div className="mt-1 text-xs">
-                  {data.flags && <>Flags: {data.flags}</>}
-                  {data.flags && data.size && " | "}
-                  {data.size && <>Size: {data.size}</>}
-                </div>
-              )}
-            </div>
-          </div>
-        </PinnedTooltipTrigger>
-        {data.tooltip && (
-          <PinnedTooltipContent className="whitespace-pre">
-            {data.tooltip}
-          </PinnedTooltipContent>
-        )}
-      </PinnedTooltip>
+          )}
+        </div>
+      </div>
       <Handle type="source" position={Position.Bottom} />
     </div>
   );


### PR DESCRIPTION
## Summary
- Remove Nebula background and use plain white background
- Simplify Record and Group nodes: transparent backgrounds, constant outline, no tooltips
- Stop assigning per-record colors in graph construction

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3be492a0832e991cf4fbf8405e59