### PR TITLE
feat: unify graph node styling

### DIFF
--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -441,12 +441,7 @@ const SampleGraph = ({
       const zskRecords = (level.records?.dnskey_records || []).filter(
         (r) => r.is_zsk
       );
-      const kskRingColor =
-        !ksk || zskRecords.length === 0
-          ? "var(--color-destructive)"
-          : undefined;
 
-      const groupRingColor = kskRingColor;
       groupNodes.push({
         id: groupId,
         type: "dnsGroup",
@@ -456,7 +451,6 @@ const SampleGraph = ({
           tooltip: `${
             level.display_name || `Level ${idx}`
           }\n${securityTooltip}`,
-          ringColor: groupRingColor,
         },
         position: { x: 0, y: 0 },
       });
@@ -469,8 +463,6 @@ const SampleGraph = ({
         data: {
           label: ksk ? "KSK" : "NO KSK",
           tooltip: kskTooltip,
-          bg: "#ffcccc",
-          ringColor: kskRingColor,
           domain: level.display_name,
           flags: ksk?.flags,
           size: ksk?.key_size,
@@ -497,8 +489,6 @@ const SampleGraph = ({
           data: {
             label: zskRecord ? "ZSK" : "NO ZSK",
             tooltip: zskTooltip,
-            bg: "#ffdddd",
-            ringColor: zskRecord ? undefined : "var(--color-destructive)",
             domain: level.display_name,
             flags: zskRecord?.flags,
             size: zskRecord?.key_size,
@@ -536,8 +526,6 @@ const SampleGraph = ({
           data: {
             label: ds ? "DS" : "NO DS",
             tooltip: dsTooltip,
-            bg: "#ccccff",
-            ringColor: ds ? undefined : "var(--color-destructive)",
             domain: level.display_name,
           },
           style: { width: nodeWidth },
@@ -582,8 +570,6 @@ const SampleGraph = ({
             data: {
               label: type,
               tooltip,
-              bg: "#ccffcc",
-              ringColor: rec.signed ? undefined : "var(--color-destructive)",
               domain: level.display_name,
             },
             style: { width: nodeWidth },

--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -9,14 +9,13 @@ export default function GroupNode({ data }) {
   // If tooltip text already includes the label don't prepend it again
   const tooltipText = data.tooltip || data.label;
 
-  const ringColor = data.ringColor || 'var(--color-primary)';
   return (
     <PinnedTooltip>
       <PinnedTooltipTrigger asChild>
         <div className="relative w-full h-full">
           <div
             className="absolute left-0 right-0 top-0 bottom-0 z-10 bg-transparent rounded-2xl border p-2 transition-all duration-200 hover:ring-2"
-            style={{ '--tw-ring-color': ringColor }}
+            style={{ '--tw-ring-color': 'var(--color-primary)', borderColor: 'var(--color-primary)' }}
           />
         </div>
       </PinnedTooltipTrigger>

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -8,7 +8,6 @@ import {
 import { computeDomain, HEADER_STYLE } from "@/lib/domain";
 
 export default function RecordNode({ data }) {
-  const ringColor = data.ringColor || "var(--color-primary)";
   const { full: domainFull, truncated } = useMemo(
     () => computeDomain(data),
     [data]
@@ -31,8 +30,9 @@ export default function RecordNode({ data }) {
               className="relative z-10 px-5 py-3 rounded-2xl border text-base transition-all duration-200 hover:ring-2 text-center"
               style={{
                 marginTop: HEADER_STYLE.visibleHeight,
-                backgroundColor: data.bg || "var(--color-background)",
-                "--tw-ring-color": ringColor,
+                backgroundColor: "var(--color-background)",
+                borderColor: "var(--color-primary)",
+                "--tw-ring-color": "var(--color-primary)",
               }}
             >
               <div>{data.label}</div>


### PR DESCRIPTION
## Summary
- remove per-record background and ring colors from SampleGraph
- apply consistent blue borders to all record and group nodes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3ea60a90832e8aa56079ff9c8b13