### PR TITLE
feat: set default zoom and size with focus display

### DIFF
--- a/src/ColorFlow.jsx
+++ b/src/ColorFlow.jsx
@@ -23,7 +23,8 @@ const ColorFlow = ({
   setRfSize,
   graphContainerRef,
 }) => {
-  const [zoom, setZoom] = useState(1);
+  const [zoom, setZoom] = useState(0.76);
+  const [focus, setFocus] = useState({ x: 0, y: 0 });
   const [fontUrl, setFontUrl] = useState("");
 
   const handleFontUrlChange = (e) => {
@@ -71,7 +72,8 @@ const ColorFlow = ({
     >
       <div className="absolute top-1 left-1 z-10 text-xs bg-secondary/80 px-2 py-1 rounded">
         Zoom: {zoom.toFixed(2)} • {Math.round(rfSize.width)}×
-        {Math.round(rfSize.height)}
+        {Math.round(rfSize.height)} • Focus: {Math.round(focus.x)},
+        {Math.round(focus.y)}
       </div>
       <div className="absolute top-1 right-1 z-10 w-48">
         <Input
@@ -91,8 +93,11 @@ const ColorFlow = ({
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             nodeTypes={nodeTypes}
-            fitView
-            onMove={(e, vp) => setZoom(vp.zoom)}
+            defaultViewport={{ x: 0, y: 0, zoom: 0.76 }}
+            onMove={(e, vp) => {
+              setZoom(vp.zoom);
+              setFocus({ x: vp.x, y: vp.y });
+            }}
             style={{ width: "100%", height: "100%", background: "transparent" }}
           >
             <Background />

--- a/src/ReactFlow.jsx
+++ b/src/ReactFlow.jsx
@@ -32,7 +32,8 @@ const ReactFlow = ({
   setRfSize,
   graphContainerRef,
 }) => {
-  const [zoom, setZoom] = useState(1);
+  const [zoom, setZoom] = useState(0.76);
+  const [focus, setFocus] = useState({ x: 0, y: 0 });
   const [fontUrl, setFontUrl] = useState("");
 
   const handleFontUrlChange = (e) => {
@@ -80,7 +81,8 @@ const ReactFlow = ({
     >
       <div className="absolute top-1 left-1 z-10 text-xs bg-secondary/80 px-2 py-1 rounded">
         Zoom: {zoom.toFixed(2)} • {Math.round(rfSize.width)}×
-        {Math.round(rfSize.height)}
+        {Math.round(rfSize.height)} • Focus: {Math.round(focus.x)},
+        {Math.round(focus.y)}
       </div>
       <div className="absolute top-1 right-1 z-10 w-48">
         <Input
@@ -102,8 +104,11 @@ const ReactFlow = ({
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             nodeTypes={nodeTypes}
-            fitView
-            onMove={(e, vp) => setZoom(vp.zoom)}
+            defaultViewport={{ x: 0, y: 0, zoom: 0.76 }}
+            onMove={(e, vp) => {
+              setZoom(vp.zoom);
+              setFocus({ x: vp.x, y: vp.y });
+            }}
             style={{ width: "100%", height: "100%" }}
           >
             <Background />

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -53,7 +53,7 @@ const setCache = (key, value) => {
  * @param {string} [props.selectedDate] - Month selected from the timeline slider (YYYY-MM)
  * @param {string} props.viewMode - Display mode (graphviz, reactflow, or reactflow-color)
  * @param {string} [props.maxWidth="56rem"] - Max width of the graph container
- * @param {string} [props.height="28rem"] - Height of the graph container
+ * @param {number|string} [props.height=1113] - Height of the graph container
  */
 const SampleGraph = ({
   domain,
@@ -63,7 +63,7 @@ const SampleGraph = ({
   selectedDate,
   viewMode,
   maxWidth = "56rem",
-  height = "28rem",
+  height = 1113,
 }) => {
   const [dot, setDot] = useState("digraph DNSSEC {}");
   const [loading, setLoading] = useState(false);
@@ -105,7 +105,7 @@ const SampleGraph = ({
 
   const [rfSize, setRfSize] = useState({
     width: parseSize(maxWidth, 896),
-    height: parseSize(height, 448),
+    height: parseSize(height, 1113),
   });
 
 


### PR DESCRIPTION
## Summary
- default ReactFlow zoom to 0.76 and display zoom focus point
- set default viewport size to 896x1113

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b1445cafc832ea226749f617863f3