### PR TITLE
Initialize ReactFlow at consistent 0.8 zoom

### DIFF
--- a/src/ColorFlow.jsx
+++ b/src/ColorFlow.jsx
@@ -23,7 +23,7 @@ const ColorFlow = ({
   setRfSize,
   graphContainerRef,
 }) => {
-  const [zoom, setZoom] = useState(0.76);
+  const [zoom, setZoom] = useState(0.8);
   const [focus, setFocus] = useState({ x: 0, y: 0 });
   const [fontUrl, setFontUrl] = useState("");
 
@@ -93,7 +93,7 @@ const ColorFlow = ({
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             nodeTypes={nodeTypes}
-            defaultViewport={{ x: 0, y: 0, zoom: 0.76 }}
+            defaultViewport={{ x: 0, y: 0, zoom: 0.8 }}
             onMove={(e, vp) => {
               setZoom(vp.zoom);
               setFocus({ x: vp.x, y: vp.y });

--- a/src/ReactFlow.jsx
+++ b/src/ReactFlow.jsx
@@ -32,7 +32,7 @@ const ReactFlow = ({
   setRfSize,
   graphContainerRef,
 }) => {
-  const [zoom, setZoom] = useState(0.76);
+  const [zoom, setZoom] = useState(0.8);
   const [focus, setFocus] = useState({ x: 0, y: 0 });
   const [fontUrl, setFontUrl] = useState("");
 
@@ -104,7 +104,7 @@ const ReactFlow = ({
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             nodeTypes={nodeTypes}
-            defaultViewport={{ x: 0, y: 0, zoom: 0.76 }}
+            defaultViewport={{ x: 0, y: 0, zoom: 0.8 }}
             onMove={(e, vp) => {
               setZoom(vp.zoom);
               setFocus({ x: vp.x, y: vp.y });

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -728,11 +728,32 @@ const SampleGraph = ({
     if (viewMode !== "reactflow" && viewMode !== "reactflow-color") return;
     const nodes = reactFlowInstance.getNodes?.() || [];
     if (!nodes.length) return;
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    nodes.forEach((n) => {
+      const x = n.positionAbsolute?.x ?? n.position?.x ?? 0;
+      const y = n.positionAbsolute?.y ?? n.position?.y ?? 0;
+      const width = n.width ?? n.measured?.width ?? 0;
+      const height = n.height ?? n.measured?.height ?? 0;
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x + width);
+      maxY = Math.max(maxY, y + height);
+    });
+    const width = maxX - minX;
+    const height = maxY - minY;
+    setRfSize({ width, height });
     const id = requestAnimationFrame(() => {
-      reactFlowInstance.fitView({ includeHiddenNodes: true, padding: 0.1 });
+      reactFlowInstance.fitBounds(
+        { x: minX, y: minY, width, height },
+        { includeHiddenNodes: true, padding: 0.1 }
+      );
+      reactFlowInstance.zoomTo?.(0.8);
     });
     return () => cancelAnimationFrame(id);
-  }, [flow, rfSize, viewMode, reactFlowInstance]);
+  }, [flow, viewMode, reactFlowInstance, setRfSize]);
 
   if (!domain) {
     return (


### PR DESCRIPTION
## Summary
- Start both standard and colorful ReactFlow components at a zoom of 0.8 by default.
- Auto-resize and center the graph on initial load only, fitting bounds once and then zooming to 0.8 without auto-fitting on subsequent viewport resizes.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b18b7df4c832e99d5576cb71cab45