### PR TITLE
Move font URL input next to domain header

### DIFF
--- a/src/ColorFlow.jsx
+++ b/src/ColorFlow.jsx
@@ -7,7 +7,6 @@ import {
 import { Resizable } from "re-resizable";
 import ErrorBoundary from "@/components/ErrorBoundary.jsx";
 import NebulaBackground from "@/components/NebulaBackground.jsx";
-import { Input } from "@/components/ui/input.jsx";
 import "@xyflow/react/dist/style.css";
 
 /**
@@ -25,39 +24,6 @@ const ColorFlow = ({
 }) => {
   const [zoom, setZoom] = useState(0.7);
   const [focus, setFocus] = useState({ x: 0, y: 0 });
-  const [fontUrl, setFontUrl] = useState("");
-
-  const handleFontUrlChange = (e) => {
-    const url = e.target.value;
-    setFontUrl(url);
-
-    const existing = document.getElementById("dynamic-node-font");
-    if (existing) existing.remove();
-
-    if (url) {
-      const link = document.createElement("link");
-      link.id = "dynamic-node-font";
-      link.rel = "stylesheet";
-      link.href = url;
-      document.head.appendChild(link);
-
-      try {
-        const u = new URL(url);
-        const familyParam = u.searchParams.get("family");
-        if (familyParam) {
-          const family = decodeURIComponent(familyParam.split(":")[0]).replace(/\+/g, " ");
-          document.documentElement.style.setProperty(
-            "--node-font-family",
-            `'${family}', sans-serif`
-          );
-        }
-      } catch {
-        // ignore URL parse errors
-      }
-    } else {
-      document.documentElement.style.removeProperty("--node-font-family");
-    }
-  };
 
   return (
     <Resizable
@@ -74,15 +40,6 @@ const ColorFlow = ({
         Zoom: {zoom.toFixed(2)} • {Math.round(rfSize.width)}×
         {Math.round(rfSize.height)} • Focus: {Math.round(focus.x)},
         {Math.round(focus.y)}
-      </div>
-      <div className="absolute top-1 right-1 z-10 w-48">
-        <Input
-          type="text"
-          placeholder="Font CSS URL"
-          value={fontUrl}
-          onChange={handleFontUrlChange}
-          className="h-8"
-        />
       </div>
       <div className="w-full h-full relative" ref={graphContainerRef}>
         <NebulaBackground />

--- a/src/ReactFlow.jsx
+++ b/src/ReactFlow.jsx
@@ -6,7 +6,6 @@ import {
 } from "@xyflow/react";
 import { Resizable } from "re-resizable";
 import ErrorBoundary from "@/components/ErrorBoundary.jsx";
-import { Input } from "@/components/ui/input.jsx";
 import "@xyflow/react/dist/style.css";
 
 /**
@@ -34,39 +33,6 @@ const ReactFlow = ({
 }) => {
   const [zoom, setZoom] = useState(0.7);
   const [focus, setFocus] = useState({ x: 0, y: 0 });
-  const [fontUrl, setFontUrl] = useState("");
-
-  const handleFontUrlChange = (e) => {
-    const url = e.target.value;
-    setFontUrl(url);
-
-    const existing = document.getElementById("dynamic-node-font");
-    if (existing) existing.remove();
-
-    if (url) {
-      const link = document.createElement("link");
-      link.id = "dynamic-node-font";
-      link.rel = "stylesheet";
-      link.href = url;
-      document.head.appendChild(link);
-
-      try {
-        const u = new URL(url);
-        const familyParam = u.searchParams.get("family");
-        if (familyParam) {
-          const family = decodeURIComponent(familyParam.split(":")[0]).replace(/\+/g, " ");
-          document.documentElement.style.setProperty(
-            "--node-font-family",
-            `'${family}', sans-serif`
-          );
-        }
-      } catch {
-        // ignore URL parse errors
-      }
-    } else {
-      document.documentElement.style.removeProperty("--node-font-family");
-    }
-  };
 
   return (
     <Resizable
@@ -83,15 +49,6 @@ const ReactFlow = ({
         Zoom: {zoom.toFixed(2)} • {Math.round(rfSize.width)}×
         {Math.round(rfSize.height)} • Focus: {Math.round(focus.x)},
         {Math.round(focus.y)}
-      </div>
-      <div className="absolute top-1 right-1 z-10 w-48">
-        <Input
-          type="text"
-          placeholder="Font CSS URL"
-          value={fontUrl}
-          onChange={handleFontUrlChange}
-          className="h-8"
-        />
       </div>
       <div
         className="w-full h-full"

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -23,6 +23,7 @@ import RecordNode from "@/components/nodes/RecordNode.jsx";
 import GroupNode from "@/components/nodes/GroupNode.jsx";
 import ReactFlow from "./ReactFlow.jsx";
 import ColorFlow from "./ColorFlow.jsx";
+import { Input } from "@/components/ui/input.jsx";
 
 import { Maximize, RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
 
@@ -107,6 +108,40 @@ const SampleGraph = ({
     width: parseSize(maxWidth, 1280),
     height: parseSize(height, 1113),
   });
+
+  const [fontUrl, setFontUrl] = useState("");
+
+  const handleFontUrlChange = (e) => {
+    const url = e.target.value;
+    setFontUrl(url);
+
+    const existing = document.getElementById("dynamic-node-font");
+    if (existing) existing.remove();
+
+    if (url) {
+      const link = document.createElement("link");
+      link.id = "dynamic-node-font";
+      link.rel = "stylesheet";
+      link.href = url;
+      document.head.appendChild(link);
+
+      try {
+        const u = new URL(url);
+        const familyParam = u.searchParams.get("family");
+        if (familyParam) {
+          const family = decodeURIComponent(familyParam.split(":")[0]).replace(/\+/g, " ");
+          document.documentElement.style.setProperty(
+            "--node-font-family",
+            `'${family}', sans-serif`
+          );
+        }
+      } catch {
+        // ignore URL parse errors
+      }
+    } else {
+      document.documentElement.style.removeProperty("--node-font-family");
+    }
+  };
 
 
   const handleExportJson = useCallback(() => {
@@ -747,11 +782,20 @@ const SampleGraph = ({
                 <h2 className="font-semibold text-lg text-foreground">
                   {domain}
                 </h2>
-                <p className="text-sm text-muted-foreground">
-                  Levels: {summary.total_levels} • Signed:{" "}
-                  {summary.signed_levels} • Breaks:{" "}
-                  {summary.chain_breaks?.length - 1 || 0}
-                </p>
+                <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                  <span>
+                    Levels: {summary.total_levels} • Signed {""}
+                    {summary.signed_levels} • Breaks {""}
+                    {summary.chain_breaks?.length - 1 || 0}
+                  </span>
+                  <Input
+                    type="text"
+                    placeholder="Font CSS URL"
+                    value={fontUrl}
+                    onChange={handleFontUrlChange}
+                    className="h-8 w-48"
+                  />
+                </div>
                 {renderTime !== null && (
                   <p className="text-xs text-muted-foreground mt-1">
                     Loaded in {renderTime} ms


### PR DESCRIPTION
## Summary
- Place Font CSS URL input alongside domain stats instead of inside graph
- Remove font URL overlays from ReactFlow and ColorFlow components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b332dd9d0832e99c49a16a40d7bcd