### PR TITLE
Add glassmorphism and glowing selection to record nodes

### DIFF
--- a/src/components/nodes/RecordNode.css
+++ b/src/components/nodes/RecordNode.css
@@ -1,0 +1,31 @@
+.record-node {
+  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 15px;
+  position: relative;
+}
+
+.record-node.selected {
+  border-color: #00ffff;
+  border-width: 2px;
+  box-shadow: 0 0 20px rgba(0, 255, 255, 0.5);
+}
+
+.record-node.selected::before {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: inherit;
+  background: conic-gradient(from 0deg, #00ffff, #ff00ff, #00ffff);
+  animation: rotate-glow 4s linear infinite;
+  z-index: -1;
+  filter: blur(8px);
+  pointer-events: none;
+}
+
+@keyframes rotate-glow {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -6,8 +6,9 @@ import {
   PinnedTooltipContent,
 } from "@/components/ui/tooltip";
 import { computeDomain, HEADER_STYLE } from "@/lib/domain";
+import "./RecordNode.css";
 
-export default function RecordNode({ data }) {
+export default function RecordNode({ data, selected }) {
   const { full: domainFull, truncated } = useMemo(
     () => computeDomain(data),
     [data]
@@ -20,25 +21,23 @@ export default function RecordNode({ data }) {
         <PinnedTooltipTrigger asChild>
           <div className="relative">
             <div
-              className="absolute top-0 left-0 right-0 z-0 rounded-t-2xl text-white text-sm font-bold tracking-[0.04em] pl-2 pt-2 select-none"
+              className="absolute top-0 left-0 right-0 z-0 rounded-t-[15px] text-white text-sm font-bold tracking-[0.04em] pl-2 pt-2 select-none"
               style={{ height: HEADER_STYLE.height, backgroundColor: headerColor }}
               title={domainFull}
             >
               {truncated}
             </div>
             <div
-              className="relative z-10 px-5 py-3 rounded-2xl border text-base transition-all duration-200 hover:ring-2 text-center"
+              className={`record-node relative z-10 px-5 py-3 text-[12px] transition-all duration-200 hover:ring-2 text-center ${selected ? "selected" : ""}`}
               style={{
                 marginTop: HEADER_STYLE.visibleHeight,
-                backgroundColor: "var(--color-background)",
-                borderColor: "var(--color-primary)",
-                "--tw-ring-color": "var(--color-primary)",
+                "--tw-ring-color": "#00ffff",
                 fontFamily: "var(--node-font-family, inherit)",
               }}
             >
-              <div>{data.label}</div>
+              <div className="font-semibold">{data.label}</div>
               {(data.flags || data.size) && (
-                <div className="mt-1 text-xs">
+                <div className="mt-1 text-[10px] opacity-80">
                   {data.flags && <>Flags: {data.flags}</>}
                   {data.flags && data.size && " | "}
                   {data.size && <>Size: {data.size}</>}


### PR DESCRIPTION
## Summary
- add glassmorphism styling for record/child nodes with blurred backdrop, translucent border, and 15px radius
- highlight selected nodes with cyan border, glow, and rotating gradient animation
- tune record-node typography to 12px main labels and 10px sublabels with reduced opacity

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c264dab68832e9160de10222bfdfa