### PR TITLE
feat: style nodes with icons and badges

### DIFF
--- a/src/ColorFlow.jsx
+++ b/src/ColorFlow.jsx
@@ -10,7 +10,7 @@ import NebulaBackground from "@/components/NebulaBackground.jsx";
 import "@xyflow/react/dist/style.css";
 
 const defaultEdgeOptions = {
-  type: "smoothstep",
+  type: "bezier",
   animated: true,
   style: { stroke: "#D1D5DB", strokeWidth: 2 },
 };

--- a/src/ReactFlow.jsx
+++ b/src/ReactFlow.jsx
@@ -9,7 +9,7 @@ import ErrorBoundary from "@/components/ErrorBoundary.jsx";
 import "@xyflow/react/dist/style.css";
 
 const defaultEdgeOptions = {
-  type: "smoothstep",
+  type: "bezier",
   animated: true,
   style: { stroke: "#D1D5DB", strokeWidth: 2 },
 };

--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -482,6 +482,7 @@ const SampleGraph = ({
           tooltip: `${
             level.display_name || `Level ${idx}`
           }\n${securityTooltip}`,
+          nodeType: levelType,
         },
         position: { x: 0, y: 0 },
       });
@@ -534,7 +535,7 @@ const SampleGraph = ({
           source: kskId,
           target: zskId,
           label: signLabel,
-          type: "smoothstep",
+          type: "bezier",
           animated: true,
           style: edgeStyle(signLabel),
           labelStyle: { background: "white", color: "black", padding: 2 },
@@ -569,7 +570,7 @@ const SampleGraph = ({
           source: firstZskId,
           target: dsId,
           label: "signs",
-          type: "smoothstep",
+          type: "bezier",
           animated: true,
           style: edgeStyle("signs"),
           labelStyle: { background: "white", color: "black", padding: 2 },
@@ -579,7 +580,7 @@ const SampleGraph = ({
           source: dsId,
           target: `ksk_${idx + 1}`,
           label: ds ? "delegates" : "no delegation",
-          type: "smoothstep",
+          type: "bezier",
           animated: true,
           labelStyle: { background: "white", color: "black", padding: 2 },
           style: edgeStyle(ds ? "delegates" : "no delegation"),
@@ -619,7 +620,7 @@ const SampleGraph = ({
             source: firstZskId,
             target: recId,
             label: edgeLabel,
-            type: "smoothstep",
+          type: "bezier",
             animated: true,
             labelStyle: { background: "white", color: "black", padding: 2 },
             style: edgeStyle(edgeLabel),

--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -1,32 +1,43 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   PinnedTooltip,
   PinnedTooltipTrigger,
   PinnedTooltipContent,
 } from "@/components/ui/tooltip";
 
+const ACCENT_GRADIENTS = {
+  root: ["#3B82F6", "#60A5FA"],
+  net: ["#10B981", "#34D399"],
+  ds: ["#8B5CF6", "#A78BFA"],
+};
+
 export default function GroupNode({ data }) {
-  // If tooltip text already includes the label don't prepend it again
   const tooltipText = data.tooltip || data.label;
+  const [start] = ACCENT_GRADIENTS[data.nodeType] || ACCENT_GRADIENTS.root;
+  const [hovered, setHovered] = useState(false);
 
   return (
     <PinnedTooltip>
       <PinnedTooltipTrigger asChild>
         <div className="relative w-full h-full">
           <div
-            className="absolute left-0 right-0 top-0 bottom-0 z-10 bg-white p-2 transition-all duration-200 hover:ring-2"
+            className="absolute left-0 right-0 top-0 bottom-0 z-10 bg-white p-2 transition-all duration-200"
             style={{
-              border: "1px solid #E5E7EB",
               borderRadius: 16,
-              boxShadow: "0 2px 4px rgba(0,0,0,0.06)",
-              "--tw-ring-color": "var(--color-primary)",
+              border: hovered ? `1px solid ${start}` : `1px solid ${start}80`,
+              boxShadow: hovered
+                ? `0 2px 4px rgba(0,0,0,0.06), 0 0 0 2px ${start}, 0 0 8px ${start}`
+                : `0 2px 4px rgba(0,0,0,0.06), 0 0 0 1px ${start}80`,
             }}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
           />
         </div>
       </PinnedTooltipTrigger>
       {tooltipText && (
         <PinnedTooltipContent
           className="whitespace-pre"
+          color={start}
           style={{ fontFamily: "var(--node-font-family, inherit)" }}
         >
           {tooltipText}

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -1,16 +1,24 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { Handle, Position } from "@xyflow/react";
 import {
   PinnedTooltip,
   PinnedTooltipTrigger,
   PinnedTooltipContent,
 } from "@/components/ui/tooltip";
+import { Badge } from "@/components/ui/badge";
+import { Globe, Network, Shield } from "lucide-react";
 import { computeDomain, HEADER_STYLE } from "@/lib/domain";
 
 const ACCENT_GRADIENTS = {
   root: ["#3B82F6", "#60A5FA"],
   net: ["#10B981", "#34D399"],
   ds: ["#8B5CF6", "#A78BFA"],
+};
+
+const NODE_ICONS = {
+  root: Globe,
+  net: Network,
+  ds: Shield,
 };
 
 const fontStack =
@@ -24,6 +32,8 @@ export default function RecordNode({ data }) {
 
   const [start, end] = ACCENT_GRADIENTS[data.nodeType] || ACCENT_GRADIENTS.root;
   const headerBackground = `linear-gradient(to right, ${start}, ${end})`;
+  const Icon = NODE_ICONS[data.nodeType] || Globe;
+  const [hovered, setHovered] = useState(false);
 
   return (
     <div className="relative flex flex-col items-center">
@@ -32,7 +42,7 @@ export default function RecordNode({ data }) {
         <PinnedTooltipTrigger asChild>
           <div className="relative">
             <div
-              className="absolute top-0 left-0 right-0 z-0 text-white text-sm font-semibold tracking-[0.04em] pl-2 pt-2 select-none"
+              className="absolute top-0 left-0 right-0 z-0 text-white text-sm font-semibold tracking-[0.04em] pl-2 pr-2 pt-2 flex items-center gap-1 select-none"
               style={{
                 height: HEADER_STYLE.height,
                 background: headerBackground,
@@ -42,26 +52,39 @@ export default function RecordNode({ data }) {
               }}
               title={domainFull}
             >
-              {truncated}
+              <Icon className="w-4 h-4" />
+              <span>{truncated}</span>
             </div>
             <div
-              className="relative z-10 px-5 py-3 text-base transition-all duration-200 hover:ring-2 text-center"
+              className="relative z-10 px-5 py-3 text-base transition-all duration-200 text-center"
               style={{
                 marginTop: HEADER_STYLE.visibleHeight,
                 backgroundColor: "var(--color-background)",
-                border: "1px solid #E5E7EB",
                 borderRadius: 16,
-                boxShadow: "0 2px 4px rgba(0,0,0,0.06)",
-                "--tw-ring-color": "var(--color-primary)",
+                border: hovered
+                  ? `1px solid ${start}`
+                  : `1px solid ${start}80`,
+                boxShadow: hovered
+                  ? `0 2px 4px rgba(0,0,0,0.06), 0 0 0 2px ${start}, 0 0 8px ${start}`
+                  : `0 2px 4px rgba(0,0,0,0.06), 0 0 0 1px ${start}80`,
                 fontFamily: data.fontFamily || fontStack,
               }}
+              onMouseEnter={() => setHovered(true)}
+              onMouseLeave={() => setHovered(false)}
             >
               <div>{data.label}</div>
               {(data.flags || data.size) && (
-                <div className="mt-1 text-xs">
-                  {data.flags && <>Flags: {data.flags}</>}
-                  {data.flags && data.size && " | "}
-                  {data.size && <>Size: {data.size}</>}
+                <div className="mt-1 flex gap-1 flex-wrap justify-center">
+                  {data.flags && (
+                    <Badge variant="secondary" className="text-[10px] px-1 py-0">
+                      Flags: {data.flags}
+                    </Badge>
+                  )}
+                  {data.size && (
+                    <Badge variant="secondary" className="text-[10px] px-1 py-0">
+                      Size: {data.size}
+                    </Badge>
+                  )}
                 </div>
               )}
             </div>
@@ -70,6 +93,7 @@ export default function RecordNode({ data }) {
         {data.tooltip && (
           <PinnedTooltipContent
             className="whitespace-pre"
+            color={start}
             style={{ fontFamily: data.fontFamily || fontStack }}
           >
             {data.tooltip}

--- a/src/components/ui/tooltip.jsx
+++ b/src/components/ui/tooltip.jsx
@@ -114,6 +114,8 @@ function PinnedTooltipContent({
   className,
   sideOffset = 0,
   children,
+  color,
+  style,
   ...props
 }) {
   const { pinned, togglePinned } = React.useContext(PinnedTooltipContext)
@@ -125,9 +127,11 @@ function PinnedTooltipContent({
         data-slot="pinned-tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          color ? "text-primary-foreground" : "bg-primary text-primary-foreground",
+          "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className
         )}
+        style={color ? { backgroundColor: color, color: "white", ...style } : style}
         {...props}
       >
         <div className="flex items-start gap-2">
@@ -138,12 +142,22 @@ function PinnedTooltipContent({
               e.stopPropagation()
               togglePinned()
             }}
-            className="text-primary-foreground/80 hover:text-primary-foreground"
+            className={cn(
+              color
+                ? "text-white/80 hover:text-white"
+                : "text-primary-foreground/80 hover:text-primary-foreground"
+            )}
           >
             <Icon className="size-3" />
           </button>
         </div>
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow
+          className={cn(
+            "z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]",
+            color ? null : "bg-primary fill-primary"
+          )}
+          style={color ? { backgroundColor: color, fill: color } : undefined}
+        />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
## Summary
- add lucide icons to node headers and show flags/size as badges
- glow nodes with color-matched tooltips and outlines
- render edges with bezier curves

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c3ed13a9c832e9dc4c88280a6162f