### PR TITLE
Style tld nodes like root and refine node text

### DIFF
--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -7,6 +7,7 @@ import {
 
 const ACCENT_GRADIENTS = {
   root: ["#3B82F6", "#60A5FA"],
+  tld: ["#3B82F6", "#60A5FA"],
   net: ["#10B981", "#34D399"],
   ds: ["#8B5CF6", "#A78BFA"],
 };

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -11,12 +11,14 @@ import { computeDomain, HEADER_STYLE } from "@/lib/domain";
 
 const ACCENT_GRADIENTS = {
   root: ["#3B82F6", "#60A5FA"],
+  tld: ["#3B82F6", "#60A5FA"],
   net: ["#10B981", "#34D399"],
   ds: ["#8B5CF6", "#A78BFA"],
 };
 
 const NODE_ICONS = {
   root: Globe,
+  tld: Globe,
   net: Network,
   ds: Shield,
 };
@@ -42,7 +44,7 @@ export default function RecordNode({ data }) {
         <PinnedTooltipTrigger asChild>
           <div className="relative">
             <div
-              className="absolute top-0 left-0 right-0 z-0 text-white text-sm font-semibold tracking-[0.04em] pl-2 pr-2 pt-2 flex items-center gap-1 select-none"
+              className="absolute top-0 left-0 right-0 z-0 text-gray-100 text-sm font-semibold tracking-[0.04em] pl-2 pr-2 pt-1 flex items-start gap-1 select-none"
               style={{
                 height: HEADER_STYLE.height,
                 background: headerBackground,
@@ -56,7 +58,7 @@ export default function RecordNode({ data }) {
               <span>{truncated}</span>
             </div>
             <div
-              className="relative z-10 px-5 py-3 text-base transition-all duration-200 text-center"
+              className="relative z-10 px-5 py-3 text-lg transition-all duration-200 text-center"
               style={{
                 marginTop: HEADER_STYLE.visibleHeight,
                 backgroundColor: "var(--color-background)",
@@ -68,6 +70,7 @@ export default function RecordNode({ data }) {
                   ? `0 2px 4px rgba(0,0,0,0.06), 0 0 0 2px ${start}, 0 0 8px ${start}`
                   : `0 2px 4px rgba(0,0,0,0.06), 0 0 0 1px ${start}80`,
                 fontFamily: data.fontFamily || fontStack,
+                lineHeight: 1.2,
               }}
               onMouseEnter={() => setHovered(true)}
               onMouseLeave={() => setHovered(false)}


### PR DESCRIPTION
## Summary
- Treat TLD nodes like root with blue gradient and globe icon
- Raise header text and use off-white color
- Enlarge child node text without changing node size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c43789638832e813891a79ab55c21