### PR TITLE
Expand DNS record node labels

### DIFF
--- a/src/SampleGraph.jsx
+++ b/src/SampleGraph.jsx
@@ -585,6 +585,13 @@ const SampleGraph = ({
           style: edgeStyle(ds ? "delegates" : "no delegation"),
         });
       } else {
+        const recordLabels = {
+          TXT: "Text",
+          MX: "Mail Exchange",
+          A: "Address",
+          AAAA: "IPv6 Address",
+          SOA: "Start of Authority",
+        };
         const recordTypes = [
           ["TXT", level.records?.txt_records],
           ["MX", level.records?.mx_records],
@@ -606,7 +613,7 @@ const SampleGraph = ({
             extent: "parent",
             draggable: true,
             data: {
-              label: type,
+              label: recordLabels[type] || type,
               tooltip,
               domain: level.display_name,
               nodeType: levelType,
@@ -619,7 +626,7 @@ const SampleGraph = ({
             source: firstZskId,
             target: recId,
             label: edgeLabel,
-          type: "bezier",
+            type: "bezier",
             animated: true,
             labelStyle: { background: "white", color: "black", padding: 2 },
             style: edgeStyle(edgeLabel),

--- a/src/examplegraph.dot
+++ b/src/examplegraph.dot
@@ -91,11 +91,11 @@ digraph DNS_Hierarchy {
         bottom_root [label="KSK", fillcolor="#ffcccc"];
         bottom_dns  [label="ZSK", fillcolor="#ffdddd"];
 
-        soa   [label="dnsviz.net/SOA",   shape=rectangle, fillcolor=white];
-        a     [label="dnsviz.net/A",     shape=rectangle, fillcolor=white];
-        aaaa  [label="dnsviz.net/AAAA",  shape=rectangle, fillcolor=white];
-        mx    [label="dnsviz.net/MX",    shape=rectangle, fillcolor=white];
-        ns    [label="dnsviz.net/NS",    shape=rectangle, fillcolor=white];
+        soa   [label="dnsviz.net/Start of Authority",   shape=rectangle, fillcolor=white];
+        a     [label="dnsviz.net/Address",               shape=rectangle, fillcolor=white];
+        aaaa  [label="dnsviz.net/IPv6 Address",          shape=rectangle, fillcolor=white];
+        mx    [label="dnsviz.net/Mail Exchange",         shape=rectangle, fillcolor=white];
+        ns    [label="dnsviz.net/Name Server",           shape=rectangle, fillcolor=white];
 
         bottom_root -> bottom_dns [label="signs"];
         bottom_dns  -> soa        [label="signs"];


### PR DESCRIPTION
## Summary
- show full names for A, AAAA, MX, SOA, TXT record nodes in SampleGraph
- update example graph to use full DNS record type names

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5ab608628832ea47e431570bc9a37