### PR TITLE
Harmonize DNS graph colors and spacing

### DIFF
--- a/src/components/nodes/GroupNode.jsx
+++ b/src/components/nodes/GroupNode.jsx
@@ -5,15 +5,10 @@ import {
   PinnedTooltipContent,
 } from "@/components/ui/tooltip";
 
-const ACCENT_GRADIENTS = {
-  root: ["#3B82F6", "#60A5FA"],
-  net: ["#10B981", "#34D399"],
-  ds: ["#8B5CF6", "#A78BFA"],
-};
+const BORDER_COLOR = "#9CA3AF";
 
 export default function GroupNode({ data }) {
   const tooltipText = data.tooltip || data.label;
-  const [start] = ACCENT_GRADIENTS[data.nodeType] || ACCENT_GRADIENTS.root;
   const [hovered, setHovered] = useState(false);
 
   return (
@@ -24,10 +19,12 @@ export default function GroupNode({ data }) {
             className="absolute left-0 right-0 top-0 bottom-0 z-10 bg-white p-2 transition-all duration-200"
             style={{
               borderRadius: 16,
-              border: hovered ? `1px solid ${start}` : `1px solid ${start}80`,
+              border: hovered
+                ? `1px solid ${BORDER_COLOR}`
+                : `1px solid ${BORDER_COLOR}80`,
               boxShadow: hovered
-                ? `0 2px 4px rgba(0,0,0,0.06), 0 0 0 2px ${start}, 0 0 8px ${start}`
-                : `0 2px 4px rgba(0,0,0,0.06), 0 0 0 1px ${start}80`,
+                ? `0 2px 4px rgba(0,0,0,0.06), 0 0 0 2px ${BORDER_COLOR}, 0 0 8px ${BORDER_COLOR}`
+                : `0 2px 4px rgba(0,0,0,0.06), 0 0 0 1px ${BORDER_COLOR}80`,
             }}
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
@@ -37,7 +34,7 @@ export default function GroupNode({ data }) {
       {tooltipText && (
         <PinnedTooltipContent
           className="whitespace-pre"
-          color={start}
+          color={BORDER_COLOR}
           style={{ fontFamily: "var(--node-font-family, inherit)" }}
         >
           {tooltipText}

--- a/src/components/nodes/RecordNode.jsx
+++ b/src/components/nodes/RecordNode.jsx
@@ -9,11 +9,12 @@ import { Badge } from "@/components/ui/badge";
 import { Globe, ShieldCheck, Anchor, Check, X } from "lucide-react";
 import { computeDomain, HEADER_STYLE } from "@/lib/domain";
 
-const ACCENT_GRADIENTS = {
-  root: ["#3B82F6", "#60A5FA"],
-  net: ["#10B981", "#34D399"],
-  ds: ["#8B5CF6", "#A78BFA"],
+const COLOR_MAP = {
+  KSK: ["#10B981", "#34D399"],
+  ZSK: ["#10B981", "#34D399"],
+  DS: ["#8B5CF6", "#A78BFA"],
 };
+const DEFAULT_GRADIENT = ["#3B82F6", "#60A5FA"];
 
 const NODE_ICONS = {
   root: Globe,
@@ -30,7 +31,12 @@ export default function RecordNode({ data }) {
     [data]
   );
 
-  const [start, end] = ACCENT_GRADIENTS[data.nodeType] || ACCENT_GRADIENTS.root;
+  const label = data.label || "";
+  const [start, end] = label.includes("KSK") || label.includes("ZSK")
+    ? COLOR_MAP.KSK
+    : label.includes("DS")
+    ? COLOR_MAP.DS
+    : DEFAULT_GRADIENT;
   const headerBackground = `linear-gradient(to right, ${start}, ${end})`;
   const Icon = useMemo(() => {
     if (data.nodeType === "root" && data.label === "KSK") {


### PR DESCRIPTION
## Summary
- standardize parent group boxes with gray borders
- apply consistent color scheme to KSK/ZSK/DS/record nodes and edge labels
- tighten node layout with smaller side padding and extra top spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8907145a0832ebaebc1f8dfdde6f2