### PR TITLE
Add export dropdown and font URL fallback

### DIFF
--- a/src/ReactFlow.jsx
+++ b/src/ReactFlow.jsx
@@ -48,7 +48,7 @@ const ReactFlow = ({
           height: rfSize.height + d.height,
         })
       }
-      className="relative border border-border rounded overflow-hidden mx-auto"
+      className="relative border border-border rounded overflow-hidden w-full"
     >
       <div className="absolute top-1 left-1 z-10 text-xs bg-secondary/80 px-2 py-1 rounded">
         Zoom: {zoom.toFixed(2)} • {Math.round(rfSize.width)}×
@@ -76,8 +76,8 @@ const ReactFlow = ({
               width: "100%",
               height: "100%",
               background: "#F9FAFB",
-              fontFamily: "'Source Sans Pro', sans-serif",
-              "--node-font-family": "'Source Sans Pro', sans-serif",
+              fontFamily:
+                "var(--node-font-family, 'Source Sans Pro', sans-serif)",
             }}
           >
             <Controls showInteractive />


### PR DESCRIPTION
## Summary
- add reload and export dropdown controls to graph card
- allow custom font CSS URLs with fallback to current font
- stretch React Flow canvas to card edges and use CSS font variable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8a971f008832e9097793adb0ef547