### PR TITLE
Add hero section with conditional graph and filler content

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import SampleGraph from "./SampleGraph.jsx";
 import { ReactFlowProvider } from "@xyflow/react";
+import FillerContent from "@/components/FillerContent.jsx";
 
 const getCache = (key) => {
   try {
@@ -35,6 +36,7 @@ export default function App() {
   // UI state
   const [domain, setDomain] = useState("");
   const [currentDomain, setCurrentDomain] = useState("");
+  const [graphGenerated, setGraphGenerated] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const dateOptions = useMemo(() => {
     const dates = [];
@@ -240,6 +242,7 @@ export default function App() {
     const cleaned = domain.trim().toLowerCase();
     if (cleaned) {
       setCurrentDomain(cleaned);
+      setGraphGenerated(true);
     }
   };
 
@@ -490,67 +493,87 @@ export default function App() {
       </header>
 
       {/* Main content */}
-      <main className="flex-grow flex items-start justify-center p-6 lg:p-10">
-        <div className="w-full max-w-[100rem] space-y-6 lg:space-y-8">
-          {/* Search bar */}
-          <div className="flex justify-center mb-4 lg:mb-6">
-            <Input
-              placeholder="example.com"
-              value={domain}
-              onChange={(e) => setDomain(e.target.value)}
-              className="w-80 h-12 lg:h-14 text-lg rounded-l-full rounded-r-none shadow-inner"
-            />
-            <Button
-              size="icon"
-              variant="secondary"
-              onClick={handleAnalyze}
-              disabled={!domain.trim()}
-              className="rounded-r-full rounded-l-none border-l-0 h-12 lg:h-14"
-              type="button"
-            >
-              <Search className="h-6 w-6" />
-            </Button>
-          </div>
-
-          {/*Timeline*/}
-          <div className="relative mb-6 h-6 lg:h-8">
-            <div className="absolute -top-10 left-0 w-full pointer-events-none">
-              <div
-                style={{ left: `${(timelineIndex / (dateOptions.length - 1)) * 100}%` }}
-                className="absolute transform -translate-x-1/2 bg-popover text-popover-foreground text-sm lg:text-base px-3 py-2 rounded shadow"
+      <main className="flex-grow">
+        {/* Hero Section with search and slider */}
+        <section className="bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 text-white text-center py-20 px-4">
+          <div className="max-w-4xl mx-auto">
+            <h1 className="text-4xl font-bold mb-4">DNSSEC Explorer</h1>
+            <p className="mb-10">Visualize and understand domain security chains.</p>
+            <div className="flex justify-center mb-6">
+              <Input
+                placeholder="example.com"
+                value={domain}
+                onChange={(e) => setDomain(e.target.value)}
+                className="w-80 h-12 lg:h-14 text-lg rounded-l-full rounded-r-none shadow-inner text-black"
+              />
+              <Button
+                size="icon"
+                variant="secondary"
+                onClick={handleAnalyze}
+                disabled={!domain.trim()}
+                className="rounded-r-full rounded-l-none border-l-0 h-12 lg:h-14"
+                type="button"
               >
-                {tooltipLabel}
+                <Search className="h-6 w-6" />
+              </Button>
+            </div>
+            <div className="relative mb-6 h-6 lg:h-8 max-w-3xl mx-auto">
+              <div className="absolute -top-10 left-0 w-full pointer-events-none">
+                <div
+                  style={{ left: `${(timelineIndex / (dateOptions.length - 1)) * 100}%` }}
+                  className="absolute transform -translate-x-1/2 bg-white text-black text-sm lg:text-base px-3 py-2 rounded shadow"
+                >
+                  {tooltipLabel}
+                </div>
+              </div>
+              <div className="relative h-full">
+                <Slider
+                  min={0}
+                  max={dateOptions.length - 1}
+                  step={1}
+                  value={[timelineIndex]}
+                  onValueChange={(v) => setTimelineIndex(v[0])}
+                  className="h-full"
+                />
+                {dateOptions.map((_, i) => (
+                  <div
+                    key={i}
+                    style={{ left: `${(i / (dateOptions.length - 1)) * 100}%` }}
+                    className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 w-px h-full bg-white/50 pointer-events-none"
+                  />
+                ))}
               </div>
             </div>
-            <div className="relative h-full">
-              <Slider
-                min={0}
-                max={dateOptions.length - 1}
-                step={1}
-                value={[timelineIndex]}
-                onValueChange={(v) => setTimelineIndex(v[0])}
-                className="h-full"
-              />
-              {dateOptions.map((_, i) => (
-                <div
-                  key={i}
-                  style={{ left: `${(i / (dateOptions.length - 1)) * 100}%` }}
-                  className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 w-px h-full bg-border/50 pointer-events-none"
-                />
-              ))}
-            </div>
           </div>
-          <ReactFlowProvider>
-            <SampleGraph
-              domain={currentDomain}
-              refreshTrigger={refreshTrigger}
-              theme={theme}
-              viewMode={viewMode}
-              onRefresh={handleRefresh}
-              userId={userId}
-              selectedDate={selectedDate.toISOString().slice(0, 7)}
-            />
-          </ReactFlowProvider>
+        </section>
+        {/* Filler content or graph */}
+        <div className="relative">
+          <div
+            className={`transition-all duration-500 ${graphGenerated ? "opacity-0 max-h-0 overflow-hidden" : "opacity-100"}`}
+          >
+            <FillerContent />
+          </div>
+          <div
+            className={`transition-opacity duration-500 ${graphGenerated ? "opacity-100" : "opacity-0 max-h-0 overflow-hidden"}`}
+          >
+            {graphGenerated && (
+              <div className="p-6 lg:p-10 flex justify-center">
+                <div className="w-full max-w-[100rem]">
+                  <ReactFlowProvider>
+                    <SampleGraph
+                      domain={currentDomain}
+                      refreshTrigger={refreshTrigger}
+                      theme={theme}
+                      viewMode={viewMode}
+                      onRefresh={handleRefresh}
+                      userId={userId}
+                      selectedDate={selectedDate.toISOString().slice(0, 7)}
+                    />
+                  </ReactFlowProvider>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       </main>
       <footer className="border-t border-border bg-card text-card-foreground p-4 text-sm">

--- a/src/components/FillerContent.jsx
+++ b/src/components/FillerContent.jsx
@@ -1,0 +1,90 @@
+import React, { useState } from "react";
+
+const slides = [
+  { src: "https://picsum.photos/seed/1/800/300", caption: "Secure your domain" },
+  { src: "https://picsum.photos/seed/2/800/300", caption: "Visualize trust chains" },
+  { src: "https://picsum.photos/seed/3/800/300", caption: "Explore DNSSEC" },
+];
+
+export default function FillerContent() {
+  const [index, setIndex] = useState(0);
+  const next = () => setIndex((index + 1) % slides.length);
+  const prev = () => setIndex((index - 1 + slides.length) % slides.length);
+  return (
+    <div className="space-y-12 py-10">
+      <div className="relative w-full max-w-3xl mx-auto">
+        <img
+          src={slides[index].src}
+          alt=""
+          className="w-full h-64 object-cover rounded"
+        />
+        <button
+          onClick={prev}
+          className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/50 text-white p-2 rounded-full"
+          type="button"
+        >
+          ‹
+        </button>
+        <button
+          onClick={next}
+          className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/50 text-white p-2 rounded-full"
+          type="button"
+        >
+          ›
+        </button>
+      </div>
+
+      <section className="max-w-3xl mx-auto space-y-4">
+        <h2 className="text-2xl font-bold">Understanding DNSSEC</h2>
+        <p>
+          Domain Name System Security Extensions (DNSSEC) add a layer of trust to
+          the DNS lookup process. This placeholder text gives a brief overview of
+          how signatures protect responses.
+        </p>
+        <p>
+          Filler content continues here explaining the benefits of DNSSEC,
+          ensuring authenticity and preventing tampering of DNS records.
+        </p>
+      </section>
+
+      <section className="max-w-3xl mx-auto space-y-4">
+        <h3 className="text-xl font-semibold">Learn More</h3>
+        <Accordion title="How DNSSEC Works">
+          <p>
+            DNSSEC uses public key cryptography to sign DNS data. Resolvers
+            verify these signatures to ensure data integrity.
+          </p>
+        </Accordion>
+        <Accordion title="Why Use DNSSEC">
+          <p>
+            It protects users from cache poisoning attacks and provides a chain
+            of trust from the root zone downward.
+          </p>
+        </Accordion>
+        <Accordion title="Deployment Challenges">
+          <p>
+            Enabling DNSSEC can be complex due to key management and coordination
+            between registrars and DNS operators.
+          </p>
+        </Accordion>
+      </section>
+    </div>
+  );
+}
+
+function Accordion({ title, children }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border-b">
+      <button
+        className="w-full flex justify-between items-center py-2 text-left font-medium"
+        onClick={() => setOpen(!open)}
+        type="button"
+      >
+        <span>{title}</span>
+        <span>{open ? "-" : "+"}</span>
+      </button>
+      {open && <div className="pb-4 text-sm">{children}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add hero section with gradient background, search bar, and timeline slider
- Introduce filler content with carousel, DNSSEC overview, and accordions
- Hide filler content and show graph once analysis is triggered

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8c0661054832eae2726545f1ca3dc