### PR TITLE
Invert scroll direction and randomize Goals background

### DIFF
--- a/src/components/GoalsBackground.jsx
+++ b/src/components/GoalsBackground.jsx
@@ -36,7 +36,7 @@ export default function GoalsBackground() {
     const topGeo = new THREE.SphereGeometry(1, 16, 8, 0, Math.PI * 2, 0, Math.PI / 2);
     const bottomGeo = new THREE.SphereGeometry(1, 16, 8, 0, Math.PI * 2, Math.PI / 2, Math.PI / 2);
 
-    const randomizeBall = (group, yPos) => {
+    const randomizeBall = (group) => {
       const radius = Math.random() * 0.3 + 0.2;
       group.scale.set(radius, radius, radius);
       group.userData.radius = radius;
@@ -54,7 +54,7 @@ export default function GoalsBackground() {
       do {
         pos.set(
           (Math.random() - 0.5) * 10,
-          yPos !== undefined ? yPos : (Math.random() - 0.5) * 10,
+          (Math.random() - 0.5) * 10,
           (Math.random() - 0.5) * 4
         );
         tries++;
@@ -78,7 +78,7 @@ export default function GoalsBackground() {
 
     let speed = 0;
     const onWheel = (e) => {
-      speed += -e.deltaY * 0.002; // scroll up -> move up
+      speed += e.deltaY * 0.002; // scroll up -> move down
     };
     window.addEventListener("wheel", onWheel);
 
@@ -95,11 +95,8 @@ export default function GoalsBackground() {
       speed *= 0.95;
       balls.forEach((ball) => {
         ball.position.y += speed;
-        if (ball.position.y > 5) {
-          randomizeBall(ball, -5);
-        }
-        if (ball.position.y < -5) {
-          randomizeBall(ball, 5);
+        if (ball.position.y > 5 || ball.position.y < -5) {
+          randomizeBall(ball);
         }
         ball.rotation.x += ball.userData.rot.x;
         ball.rotation.y += ball.userData.rot.y;


### PR DESCRIPTION
## Summary
- Invert wheel control for Goals hero background so upward scrolling moves the scene downward.
- Randomize ball generation throughout space to avoid layered respawns.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaec8d9d4c832e9b146ceda7278353