### PR TITLE
Load goals background models from OBJ files

### DIFF
--- a/src/pages/Goals.jsx
+++ b/src/pages/Goals.jsx
@@ -1,9 +1,15 @@
 import GoalsBackground from "@/components/GoalsBackground.jsx";
 
+const modelUrls = [
+  "https://threejs.org/examples/models/obj/walt/WaltHead.obj",
+  "https://threejs.org/examples/models/obj/female02/female02.obj",
+  "https://threejs.org/examples/models/obj/male02/male02.obj",
+];
+
 export default function Goals() {
   return (
     <section className="relative min-h-screen overflow-hidden bg-[#f8f8f8]">
-      <GoalsBackground />
+      <GoalsBackground modelUrls={modelUrls} />
       <div className="relative z-10 p-6 pt-24 text-center">
         <h2 className="text-2xl font-bold mb-4">Goals</h2>
         <p>This is a placeholder page for goals.</p>


### PR DESCRIPTION
## Summary
- Replace hardcoded geometries with OBJLoader-based models for goals background
- Allow model URLs to be supplied externally and pass example OBJ links from goals page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaee75ee50832e8303e8cb376496c3