### PR TITLE
fix: import GoalsBackground component

### DIFF
--- a/src/pages/Goals.jsx
+++ b/src/pages/Goals.jsx
@@ -1,6 +1,7 @@
 import chainModel from "@/assets/models/chain.obj?url";
 import lockModel from "@/assets/models/lock.obj?url";
 import keyModel from "@/assets/models/key.obj?url";
+import GoalsBackground from "@/components/GoalsBackground";
 
 // Use locally imported models so the background works offline
 const modelUrls = [chainModel, lockModel, keyModel];


### PR DESCRIPTION
## Summary
- import GoalsBackground so Goals page renders its background

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaff7baa0c832ebbc7597e2efc96d4