### PR TITLE
fix: enable transparent goals background

### DIFF
--- a/src/components/GoalsBackground.jsx
+++ b/src/components/GoalsBackground.jsx
@@ -28,10 +28,11 @@ export default function GoalsBackground({
     const renderer = new THREE.WebGLRenderer({
       antialias: true,
       powerPreference: "high-performance",
+      alpha: true,
     });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
     renderer.setSize(mount.clientWidth, mount.clientHeight);
-    renderer.setClearColor(0xf8f8f8); // offwhite background
+    renderer.setClearColor(0x000000, 0); // transparent background
     mount.appendChild(renderer.domElement);
 
     const ambient = new THREE.AmbientLight(0xffffff, 0.8);
@@ -156,5 +157,10 @@ export default function GoalsBackground({
     };
   }, [modelUrls]);
 
-  return <div ref={mountRef} className="absolute inset-0" />;
+  return (
+    <div
+      ref={mountRef}
+      className="absolute inset-0 -z-10 pointer-events-none"
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- allow Goals background renderer transparency so CSS shows through
- place Goals background canvas behind content and ignore pointer events

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab07b778ec832ebbfef852769500f8