### PR TITLE
feat: redesign goals page with horizontal scroll

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ import SampleGraph from "./SampleGraph.jsx";
 import { ReactFlowProvider } from "@xyflow/react";
 import FillerContent from "@/components/FillerContent.jsx";
 import ThreeHero from "@/components/ThreeHero.jsx";
-import { Routes, Route, Link } from "react-router-dom";
+import { Routes, Route, Link, useLocation } from "react-router-dom";
 import Blog from "@/pages/Blog.jsx";
 import About from "@/pages/About.jsx";
 import Support from "@/pages/Support.jsx";
@@ -64,6 +64,7 @@ export default function App() {
   );
   const [loginOpen, setLoginOpen] = useState(true);
   const [signupOpen, setSignupOpen] = useState(false);
+  const location = useLocation();
 
   // Login state
   const [loginEmail, setLoginEmail] = useState("");
@@ -516,34 +517,36 @@ export default function App() {
           <Route path="/license" element={<License />} />
         </Routes>
       </main>
-      <footer className="border-t border-border bg-card text-card-foreground p-4 text-sm">
-        <div className="max-w-7xl mx-auto flex flex-col sm:flex-row justify-between gap-4">
-          <div>
-            <p className="font-semibold">DNSCAP</p>
-            <p className="text-xs">Demo dashboard for domain analysis.</p>
+      {location.pathname !== "/goals" && (
+        <footer className="border-t border-border bg-card text-card-foreground p-4 text-sm">
+          <div className="max-w-7xl mx-auto flex flex-col sm:flex-row justify-between gap-4">
+            <div>
+              <p className="font-semibold">DNSCAP</p>
+              <p className="text-xs">Demo dashboard for domain analysis.</p>
+            </div>
+            <div className="flex space-x-4">
+              <Link to="/blog" className="hover:underline">
+                Blog
+              </Link>
+              <Link to="/about" className="hover:underline">
+                About
+              </Link>
+              <Link to="/support" className="hover:underline">
+                Support
+              </Link>
+              <Link to="/policy" className="hover:underline">
+                Policy
+              </Link>
+              <Link to="/license" className="hover:underline">
+                License
+              </Link>
+            </div>
+            <p className="text-xs sm:text-sm">
+              &copy; 2025 EUNOMATIX. All rights reserved.
+            </p>
           </div>
-          <div className="flex space-x-4">
-            <Link to="/blog" className="hover:underline">
-              Blog
-            </Link>
-            <Link to="/about" className="hover:underline">
-              About
-            </Link>
-            <Link to="/support" className="hover:underline">
-              Support
-            </Link>
-            <Link to="/policy" className="hover:underline">
-              Policy
-            </Link>
-            <Link to="/license" className="hover:underline">
-              License
-            </Link>
-          </div>
-          <p className="text-xs sm:text-sm">
-            &copy; 2025 EUNOMATIX. All rights reserved.
-          </p>
-        </div>
-      </footer>
+        </footer>
+      )}
     </div>
   );
 }

--- a/src/pages/Goals.jsx
+++ b/src/pages/Goals.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import chainModel from "@/assets/models/chain.obj?url";
 import lockModel from "@/assets/models/lock.obj?url";
 import keyModel from "@/assets/models/key.obj?url";
@@ -6,13 +7,74 @@ import GoalsBackground from "@/components/GoalsBackground";
 // Use locally imported models so the background works offline
 const modelUrls = [chainModel, lockModel, keyModel];
 
+const sections = [
+  {
+    title: "Unchain Your Potential",
+    text: "Explore how our platform empowers you to break barriers and reach new heights.",
+  },
+  {
+    title: "Forge Strong Connections",
+    text: "Collaborate with others and build meaningful networks that drive success.",
+  },
+  {
+    title: "Unlock Success",
+    text: "Leverage intuitive tools and insights to achieve your goals efficiently.",
+  },
+  {
+    title: "Secure Your Future",
+    text: "Stay informed and prepared with up‑to‑date resources and guidance.",
+  },
+];
+
 export default function Goals() {
+  const containerRef = useRef(null);
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleWheel = (e) => {
+      e.preventDefault();
+      container.scrollBy({ left: e.deltaY, behavior: "smooth" });
+    };
+
+    const handleScroll = () => {
+      const max = container.scrollWidth - container.clientWidth;
+      const pct = (container.scrollLeft / max) * 100;
+      setProgress(pct);
+    };
+
+    container.addEventListener("wheel", handleWheel, { passive: false });
+    container.addEventListener("scroll", handleScroll);
+    return () => {
+      container.removeEventListener("wheel", handleWheel);
+      container.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
   return (
     <section className="relative min-h-screen overflow-hidden bg-[#f8f8f8]">
       <GoalsBackground modelUrls={modelUrls} />
-      <div className="relative z-10 p-6 pt-24 text-center">
-        <h2 className="text-2xl font-bold mb-4">Goals</h2>
-        <p>This is a placeholder page for goals.</p>
+      <div
+        ref={containerRef}
+        className="relative z-10 flex h-screen overflow-x-scroll overflow-y-hidden snap-x snap-mandatory scroll-smooth"
+      >
+        {sections.map((s, i) => (
+          <div
+            key={i}
+            className="flex-shrink-0 w-screen h-full flex flex-col items-center justify-center p-10 text-center snap-start"
+          >
+            <h2 className="text-4xl font-bold mb-4">{s.title}</h2>
+            <p className="max-w-md text-lg">{s.text}</p>
+          </div>
+        ))}
+      </div>
+      <div className="fixed bottom-0 left-0 w-full h-1 bg-gray-200">
+        <div
+          className="h-full bg-gray-800 transition-all duration-150"
+          style={{ width: `${progress}%` }}
+        />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- redesign Goals page with horizontal sideways scroll and hero tagline sections
- show progress bar during scroll and remove footer on goals route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab1aec7fa4832ea9fae2d1fafe2397