### PR TITLE
feat: layered goals background with camera transitions

### DIFF
--- a/src/pages/Goals.jsx
+++ b/src/pages/Goals.jsx
@@ -67,7 +67,12 @@ export default function Goals() {
       className="relative min-h-screen overflow-hidden"
       style={{ backgroundColor: bgColor, transition: "background-color 0.8s ease" }}
     >
-      <GoalsBackground modelUrls={modelUrls} bgColor={bgColor} />
+      <GoalsBackground
+        modelUrls={modelUrls}
+        bgColor={bgColor}
+        activeIndex={activeIndex}
+        sectionCount={sections.length}
+      />
       <div
         ref={containerRef}
         className="relative z-10 flex h-screen overflow-x-scroll overflow-y-hidden snap-x snap-mandatory scroll-smooth scrollbar-hide"


### PR DESCRIPTION
## Summary
- replace infinite scroll with layered 3D scene using copies of one model per section
- animate camera through layers based on active section index
- wire Goals page to drive background section and camera

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac425f9c9c832ea4b448bb69abc45f