### PR TITLE
Invert goals scroll and remove home hero

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,6 @@ import {
 import SampleGraph from "./SampleGraph.jsx";
 import { ReactFlowProvider } from "@xyflow/react";
 import FillerContent from "@/components/FillerContent.jsx";
-import ThreeHero from "@/components/ThreeHero.jsx";
 import { Routes, Route, Link, useLocation } from "react-router-dom";
 import Blog from "@/pages/Blog.jsx";
 import About from "@/pages/About.jsx";
@@ -278,7 +277,6 @@ export default function App() {
       <>
         {/* Hero Section */}
         <section className="relative text-center py-20 px-4 overflow-hidden min-h-[92vh] bg-[#0077b6]">
-          <ThreeHero />
           <div className="relative z-10 max-w-4xl mx-auto">
             <h1 className="text-4xl font-bold mb-4">DNSSEC Explorer</h1>
             <p className="mb-10">Visualize and understand domain security chains.</p>

--- a/src/pages/Goals.jsx
+++ b/src/pages/Goals.jsx
@@ -42,7 +42,7 @@ export default function Goals() {
 
     const handleWheel = (e) => {
       e.preventDefault();
-      container.scrollBy({ left: e.deltaY, behavior: "smooth" });
+      container.scrollBy({ left: -e.deltaY, behavior: "smooth" });
     };
 
     const handleScroll = () => {


### PR DESCRIPTION
## Summary
- invert horizontal scrolling direction in Goals page
- remove Three.js hero background from Home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac55d9a11c832e85575c8e4e4b8285