### PR TITLE
Ignore stats.json updates to avoid dev reload loops

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -14,4 +14,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    watch: {
+      ignored: ["**/stats.json"],
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- Ignore `stats.json` in Vite dev server watch configuration to prevent unnecessary reloads when the file changes

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb73c8b80832e8c637b46d60e7293