### PR TITLE
feat: add domain statistics chart

### DIFF
--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -1,5 +1,17 @@
 import { useEffect, useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 export default function Stats() {
   const [stats, setStats] = useState({ total: 0, domains: {} });
@@ -11,18 +23,73 @@ export default function Stats() {
       .catch(() => setStats({ total: 0, domains: {} }));
   }, []);
 
-  const popularDomain = Object.entries(stats.domains || {})
-    .sort((a, b) => b[1] - a[1])[0]?.[0];
+  const domainData = Object.entries(stats.domains || {})
+    .map(([domain, count]) => ({ domain, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const chartConfig = {
+    count: {
+      label: "Graphs",
+      color: "hsl(var(--chart-1))",
+    },
+  };
 
   return (
-    <div className="max-w-3xl mx-auto p-6 pt-24">
+    <div className="max-w-3xl mx-auto p-6 pt-24 space-y-6">
       <Card>
         <CardHeader>
           <CardTitle>Website Statistics</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <p>Total graphs generated: {stats.total || 0}</p>
-          <p>Most popular domain: {popularDomain || "N/A"}</p>
+
+          {domainData.length > 0 ? (
+            <>
+              <ChartContainer
+                config={chartConfig}
+                className="h-[300px] w-full"
+              >
+                <BarChart data={domainData}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis
+                    dataKey="domain"
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <YAxis
+                    allowDecimals={false}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <ChartTooltip
+                    cursor={false}
+                    content={<ChartTooltipContent />}
+                  />
+                  <Bar
+                    dataKey="count"
+                    fill="var(--color-count)"
+                    radius={[4, 4, 0, 0]}
+                  />
+                </BarChart>
+              </ChartContainer>
+
+              <ul className="space-y-1">
+                {domainData.map((item, index) => (
+                  <li
+                    key={item.domain}
+                    className="flex justify-between text-sm"
+                  >
+                    <span>
+                      {index + 1}. {item.domain}
+                    </span>
+                    <span>{item.count}</span>
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <p>No domain data available.</p>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- visualize per-domain graph counts on stats page using shadcn chart
- list domains ranked by generated graph totals

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adbc7562a8832e9d698492365ab277