### PR TITLE
Set selected domain stats line to black

### DIFF
--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -49,10 +49,17 @@ export default function Stats() {
     .map(([domain, count]) => ({ domain, count }))
     .sort((a, b) => b.count - a.count);
 
-  const chartConfig = {
+  const domainChartConfig = {
     count: {
       label: "Views",
       color: "hsl(var(--chart-1))",
+    },
+  };
+
+  const historyChartConfig = {
+    count: {
+      label: "Views",
+      color: "black",
     },
   };
 
@@ -68,7 +75,7 @@ export default function Stats() {
           {domainData.length > 0 ? (
             <>
               <ChartContainer
-                config={chartConfig}
+                config={domainChartConfig}
                 className="h-[300px] w-full"
               >
                 <BarChart data={domainData}>
@@ -116,7 +123,7 @@ export default function Stats() {
                     Views for {selectedDomain}
                   </h3>
                   <ChartContainer
-                    config={chartConfig}
+                    config={historyChartConfig}
                     className="h-[300px] w-full"
                   >
                     <LineChart data={domainHistory}>


### PR DESCRIPTION
## Summary
- ensure the single-domain stats graph uses a black line to display values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68add227bbcc832e91ddc35b92b53b92