### PR TITLE
Add individual blog post pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -1142,6 +1142,16 @@ def get_posts():
     return _read_blog_posts()
 
 
+@app.get("/posts/{post_id}")
+def get_post(post_id: str):
+    """Return a single blog post by its ID."""
+    posts = _read_blog_posts()
+    for post in posts:
+        if post["id"] == post_id:
+            return post
+    raise HTTPException(status_code=404, detail="Post not found")
+
+
 @app.post("/posts")
 def create_post(post: BlogPost):
     posts = _read_blog_posts()

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import { ReactFlowProvider } from "@xyflow/react";
 import FillerContent from "@/components/FillerContent.jsx";
 import { Routes, Route, Link, useLocation } from "react-router-dom";
 import Blog from "@/pages/Blog.jsx";
+import BlogPost from "@/pages/BlogPost.jsx";
 import WriteBlog from "@/pages/WriteBlog.jsx";
 import About from "@/pages/About.jsx";
 import Support from "@/pages/Support.jsx";
@@ -637,7 +638,8 @@ export default function App() {
           />
           <Route path="/goals" element={<Goals />} />
           <Route path="/goals2" element={<Goals2 />} />
-          <Route path="/blog" element={<Blog />} />
+            <Route path="/blog" element={<Blog />} />
+            <Route path="/blog/:id" element={<BlogPost />} />
           <Route path="/writeblog" element={<WriteBlog />} />
           <Route path="/about" element={<About />} />
           <Route path="/support" element={<Support />} />

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   Card,
   CardHeader,
@@ -18,19 +19,33 @@ export default function Blog() {
 
   return (
     <div className="max-w-4xl mx-auto p-6 pt-24 space-y-6">
-      {posts.map((post) => (
-        <Card key={post.id}>
-          <CardHeader>
-            <CardTitle>{post.title}</CardTitle>
-            <CardDescription>
-              {new Date(post.date).toLocaleDateString()}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div dangerouslySetInnerHTML={{ __html: post.content }} />
-          </CardContent>
-        </Card>
-      ))}
+      {posts.map((post) => {
+        const text = post.content.replace(/<[^>]+>/g, "");
+        const snippet = text.length > 200 ? text.slice(0, 200) + "..." : text;
+        return (
+          <Card key={post.id}>
+            <CardHeader>
+              <CardTitle>
+                <Link to={`/blog/${post.id}`} className="hover:underline">
+                  {post.title}
+                </Link>
+              </CardTitle>
+              <CardDescription>
+                {new Date(post.date).toLocaleDateString()}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="mb-2">{snippet}</p>
+              <Link
+                to={`/blog/${post.id}`}
+                className="text-blue-500 hover:underline"
+              >
+                Read more
+              </Link>
+            </CardContent>
+          </Card>
+        );
+      })}
     </div>
   );
 }

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+
+export default function BlogPost() {
+  const { id } = useParams();
+  const [post, setPost] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch(`http://127.0.0.1:8000/posts/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Post not found");
+        return res.json();
+      })
+      .then((data) => setPost(data))
+      .catch((err) => setError(err.message));
+  }, [id]);
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto p-6 pt-24">
+        <p className="mb-4 text-red-500">{error}</p>
+        <Link to="/blog" className="text-blue-500 hover:underline">
+          Back to blog
+        </Link>
+      </div>
+    );
+  }
+
+  if (!post) {
+    return <div className="max-w-4xl mx-auto p-6 pt-24">Loading...</div>;
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 pt-24 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{post.title}</CardTitle>
+          <CardDescription>
+            {new Date(post.date).toLocaleDateString()}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div dangerouslySetInnerHTML={{ __html: post.content }} />
+        </CardContent>
+      </Card>
+      <Link to="/blog" className="text-blue-500 hover:underline">
+        ← Back to all posts
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add endpoint to fetch single blog posts by ID
- Link blog listings to dedicated post pages with snippets
- Create new `BlogPost` React page and route for individual posts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ade3bbbef0832eb1277f2bf7252b1f