### PR TITLE
feat: add profile page with user settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -185,8 +185,9 @@ export default function App() {
   const [loginEmail, setLoginEmail] = useState("");
   const [loginPassword, setLoginPassword] = useState("");
   const [loginError, setLoginError] = useState("");
-  const [, setUsername] = useState("");
-  const [, setProfilePic] = useState(null);
+  const [username, setUsername] = useState("");
+  const [profilePic, setProfilePic] = useState(null);
+  const [userEmail, setUserEmail] = useState("");
   const [userId, setUserId] = useState(null);
   const [rememberMe, setRememberMe] = useState(false);
 
@@ -200,6 +201,7 @@ export default function App() {
           setUsername(data.username || "");
           setProfilePic(data.profilePic || null);
           setUserId(data.userId || null);
+          setUserEmail(data.email || "");
           setLoginOpen(false);
           setRememberMe(true);
           return;
@@ -321,6 +323,7 @@ export default function App() {
         setUsername(data.success);
         setProfilePic(data.picture || null);
         setUserId(data.id || null);
+        setUserEmail(data.email || "");
         resetGraphUses();
         setLoginOpen(false);
         setSignupOpen(false);
@@ -331,6 +334,7 @@ export default function App() {
               username: data.success,
               profilePic: data.picture || null,
               userId: data.id || null,
+              email: data.email || "",
               expiry: Date.now() + 24 * 60 * 60 * 1000,
             })
           );
@@ -359,6 +363,7 @@ export default function App() {
         setUsername(successVal);
         setProfilePic(null);
         setUserId(data.id || null);
+        setUserEmail(loginEmail);
         resetGraphUses();
         setLoginError("");
         setLoginOpen(false);
@@ -369,6 +374,7 @@ export default function App() {
               username: successVal,
               profilePic: null,
               userId: data.id || null,
+              email: loginEmail,
               expiry: Date.now() + 24 * 60 * 60 * 1000,
             })
           );
@@ -457,7 +463,24 @@ export default function App() {
     }
     setRefreshTrigger((prev) => prev + 1);
   };
-  // Removed theme toggle and logout handlers with the new navbar
+  const handleLogout = async () => {
+    if (userId) {
+      try {
+        await fetch(`http://127.0.0.1:8000/logout/${userId}`);
+      } catch {
+        // ignore network errors
+      }
+    }
+    setUsername("");
+    setProfilePic(null);
+    setUserEmail("");
+    setUserId(null);
+    localStorage.removeItem("rememberMe");
+    resetGraphUses();
+    setLoginOpen(true);
+  };
+
+  // Removed theme toggle handler with the new navbar
 
   //tooltip
   const selectedDate = dateOptions[timelineIndex] || new Date();
@@ -646,7 +669,17 @@ export default function App() {
           <Route path="/support" element={<Support />} />
           <Route path="/policy" element={<Policy />} />
           <Route path="/license" element={<License />} />
-          <Route path="/profile" element={<Profile />} />
+          <Route
+            path="/profile"
+            element={
+              <Profile
+                username={username}
+                email={userEmail}
+                profilePic={profilePic}
+                onLogout={handleLogout}
+              />
+            }
+          />
           <Route
             path="/history"
             element={<History userId={userId} viewMode={viewMode} />}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,8 +1,59 @@
-export default function Profile() {
+import { Link } from "react-router-dom";
+import { User } from "lucide-react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function Profile({ username, email, profilePic, onLogout }) {
   return (
-    <div className="max-w-3xl mx-auto p-6 pt-24">
-      <h1 className="text-2xl font-bold mb-4">Profile</h1>
-      <p>Your profile details will appear here.</p>
+    <div className="max-w-3xl mx-auto p-6 pt-24 space-y-6">
+      <Card className="flex flex-col items-center p-6 space-y-4">
+        {profilePic ? (
+          <img
+            src={profilePic}
+            alt="Profile"
+            className="w-24 h-24 rounded-full object-cover"
+          />
+        ) : (
+          <div className="w-24 h-24 rounded-full bg-muted flex items-center justify-center">
+            <User className="w-12 h-12 text-muted-foreground" />
+          </div>
+        )}
+        <div className="text-center">
+          <h2 className="text-xl font-bold">{username || "User"}</h2>
+          <p className="text-muted-foreground">{email || "No email"}</p>
+        </div>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Settings</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Button asChild className="w-full">
+            <Link to="/history">View History</Link>
+          </Button>
+          <div className="space-y-2">
+            <div>
+              <label className="block text-sm font-medium mb-1">Language</label>
+              <select className="w-full p-2 border rounded-md">
+                <option>English</option>
+                <option>Spanish</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Region</label>
+              <select className="w-full p-2 border rounded-md">
+                <option>US</option>
+                <option>EU</option>
+              </select>
+            </div>
+          </div>
+          <Button onClick={onLogout} variant="destructive" className="w-full">
+            Log out
+          </Button>
+        </CardContent>
+      </Card>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- show profile picture, name, email, and settings in new Profile page
- manage user session data and logout logic in App

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeee75e9f8832eb6fa39179fcf596f