### PR TITLE
Scale globe and attach rotating dots

### DIFF
--- a/src/components/GlobeScene.jsx
+++ b/src/components/GlobeScene.jsx
@@ -51,12 +51,16 @@ export default function GlobeScene({ modelUrl = globeModel, onSetRotation }) {
         const dot = new THREE.Mesh(geometry, material);
         dot.position.copy(randomPointOnSphere(radius));
         dot.userData.value = Math.floor(Math.random() * 1000);
-        scene.add(dot);
+        // Attach dots to the globe so they rotate together
+        globeRef.current.add(dot);
         dots.push(dot);
       }
     };
 
     loader.load(modelUrl, (obj) => {
+      // Increase the overall scale of the globe
+      const scale = 1.5;
+      obj.scale.setScalar(scale);
       globeRef.current = obj;
       scene.add(globeRef.current);
       const box = new THREE.Box3().setFromObject(obj);


### PR DESCRIPTION
## Summary
- Enlarge globe model for bigger on-screen presence without expanding view port
- Attach generated dots to the globe so they move and spin with the model

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b028dc4048832e8e4712eabd2c0485