### PR TITLE
Ensure globe camera starts outside model radius

### DIFF
--- a/src/components/GlobeScene.jsx
+++ b/src/components/GlobeScene.jsx
@@ -29,7 +29,8 @@ export default function GlobeScene({
       1000
     );
     // Offset camera so about 60% of the globe is visible
-    camera.position.set(1.2, 0, 3);
+    // and ensure it starts outside the globe's radius
+    camera.position.set(2.4, 0, 6);
     camera.lookAt(0, 0, 0);
 
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });


### PR DESCRIPTION
## Summary
- Move camera farther from origin to keep it outside the scaled globe
- Clarify camera placement with additional comment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0323f9c10832e9162a20094f441c9