### PR TITLE
Illuminate globe in Goals2

### DIFF
--- a/src/components/GlobeScene.jsx
+++ b/src/components/GlobeScene.jsx
@@ -22,6 +22,13 @@ export default function GlobeScene({
     if (!mount) return;
 
     const scene = new THREE.Scene();
+    // basic lighting so the globe isn't rendered black
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.8);
+    scene.add(ambientLight);
+    const directionalLight = new THREE.DirectionalLight(0xffffff, 0.6);
+    directionalLight.position.set(5, 5, 5);
+    scene.add(directionalLight);
+
     const camera = new THREE.PerspectiveCamera(
       60,
       mount.clientWidth / mount.clientHeight,


### PR DESCRIPTION
## Summary
- add ambient and directional lights in GlobeScene so the globe isn't rendered black

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b03a0f7674832e8209a9a7a0a9d49d