### PR TITLE
Load globe textures asynchronously

### DIFF
--- a/src/components/GlobeScene.jsx
+++ b/src/components/GlobeScene.jsx
@@ -79,10 +79,13 @@ export default function GlobeScene({
     mtlLoader.load(mtlUrl, (materials) => {
       materials.preload();
       objLoader.setMaterials(materials);
-      objLoader.load(modelUrl, (obj) => {
-        const diffuseMap = textureLoader.load(diffuseTexture);
-        const bumpMap = textureLoader.load(bumpTexture);
-        const cloudsMap = textureLoader.load(cloudsTexture);
+      objLoader.load(modelUrl, async (obj) => {
+        const [diffuseMap, bumpMap, cloudsMap] = await Promise.all([
+          textureLoader.loadAsync(diffuseTexture),
+          textureLoader.loadAsync(bumpTexture),
+          textureLoader.loadAsync(cloudsTexture),
+        ]);
+
         obj.traverse((child) => {
           if (child.isMesh && child.material) {
             const name = child.material.name;
@@ -99,6 +102,7 @@ export default function GlobeScene({
             child.material.needsUpdate = true;
           }
         });
+
         // Increase the overall scale of the globe
         const scale = 1.5;
         obj.scale.setScalar(scale);


### PR DESCRIPTION
## Summary
- load globe textures concurrently using `TextureLoader.loadAsync`
- update materials after `Promise.all` resolves and mark for refresh

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b03bd195f4832e92fc91cef7e452eb