### PR TITLE
Round hero card edges in Goals2

### DIFF
--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -51,7 +51,7 @@ export default function Goals2() {
   return (
     <div className="min-h-screen bg-white flex flex-col">
         <section
-          className="relative flex flex-col items-center justify-center h-[calc(100vh-1.5rem-20px)] rounded-b-3xl overflow-hidden pt-6 pl-6 pr-8 mt-[10px] mx-[10px] mb-[calc(1.5rem+10px)]"
+          className="relative flex flex-col items-center justify-center h-[calc(100vh-1.5rem-20px)] rounded-3xl overflow-hidden pt-6 pl-6 pr-8 mt-[10px] mx-[10px] mb-[calc(1.5rem+10px)]"
           style={{ backgroundColor: "#8F00FF" }}
         >
         <div className="flex items-center justify-center gap-8">


### PR DESCRIPTION
## Summary
- Round the Goals2 hero section background on all sides with `rounded-3xl`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0518b260c832e9827ee3b416abc70