### PR TITLE
Increase graph card width in Goals2

### DIFF
--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -119,7 +119,7 @@ export default function Goals2() {
           >
             {graphGenerated && (
               <div className="p-6 lg:p-10 flex justify-center">
-                <div className="w-full max-w-4xl">
+                <div className="w-full max-w-6xl">
                   <div className="flex items-center justify-end gap-2 mb-4">
                     <Calendar className="w-5 h-5 text-gray-700" />
                     <Slider


### PR DESCRIPTION
## Summary
- widen Goals2 graph card container for larger visualizations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0709b81e0832e8f5d2349f35d6a5f