### PR TITLE
Render low-poly earth with GlobeScene

### DIFF
--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useEffect, useRef } from "react";
 import ModelViewer from "@/components/ModelViewer";
+import GlobeScene from "@/components/GlobeScene";
 import lowPolyEarth from "@/assets/models/uploads_files_5480147_low_poly_earth.glb?url";
 import animatedClock from "@/assets/models/animated_clock.glb?url";
 import lightning from "@/assets/models/lightning_bolt_icons.glb?url";
@@ -81,10 +82,11 @@ export default function Goals2() {
             The Better
           </span>
           <div className="w-72 h-72 md:w-96 md:h-96">
-            <ModelViewer
+            <GlobeScene
               modelUrl={lowPolyEarth}
-              scale={1.5}
-              initialRotation={{ x: tilt, y: 0, z: 0 }}
+              onSetRotation={(setRotation) =>
+                setRotation({ x: tilt, y: 0 })
+              }
             />
           </div>
           <span


### PR DESCRIPTION
## Summary
- Display spinning low-poly earth in Goals2 using GlobeScene
- Extend GlobeScene to load GLB models via GLTFLoader

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b183db2d38832ea25ac48a8eef4a95