### PR TITLE
Add interactive space section and dynamic stats

### DIFF
--- a/src/components/GlobeScene.jsx
+++ b/src/components/GlobeScene.jsx
@@ -14,6 +14,7 @@ export default function GlobeScene({
   modelUrl = earthModel,
   mtlUrl = earthMaterial,
   onSetRotation,
+  distance = 1,
 }) {
   const mountRef = useRef(null);
   const globeRef = useRef();
@@ -153,8 +154,8 @@ export default function GlobeScene({
       const size = box.getSize(new THREE.Vector3());
       const radius = Math.max(size.x, size.y, size.z) / 2;
       addDots(radius, DOT_COUNT);
-      const camX = radius * 3.3;
-      const camZ = radius * 2;
+      const camX = radius * 3.3 * distance;
+      const camZ = radius * 2 * distance;
       camera.position.set(camX, 0, camZ);
       camera.lookAt(0, 0, 0);
       controls.update();
@@ -288,7 +289,7 @@ export default function GlobeScene({
       if (dotIntervalRef.current) clearInterval(dotIntervalRef.current);
       renderer.dispose();
     };
-  }, [modelUrl, mtlUrl, onSetRotation]);
+  }, [modelUrl, mtlUrl, onSetRotation, distance]);
 
   return <div ref={mountRef} className="w-full h-full" />;
 }

--- a/src/components/NumberTicker.jsx
+++ b/src/components/NumberTicker.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+export default function NumberTicker({ start, className = "" }) {
+  const [value, setValue] = useState(0);
+
+  useEffect(() => {
+    let raf;
+    let timeout;
+    let current = 0;
+    const target = start;
+
+    const animateToTarget = () => {
+      current += Math.ceil((target - current) / 10);
+      setValue(current);
+      if (current < target) {
+        raf = requestAnimationFrame(animateToTarget);
+      } else {
+        const tick = () => {
+          setValue((v) => v + Math.floor(Math.random() * 1000) + 500);
+          timeout = setTimeout(tick, Math.random() * 2000 + 1000);
+        };
+        timeout = setTimeout(tick, Math.random() * 2000 + 1000);
+      }
+    };
+
+    raf = requestAnimationFrame(animateToTarget);
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [start]);
+
+  return <span className={className}>{value.toLocaleString()}</span>;
+}

--- a/src/components/SpaceScene.jsx
+++ b/src/components/SpaceScene.jsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef } from "react";
+
+export default function SpaceScene() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    container.appendChild(canvas);
+
+    const resize = () => {
+      canvas.width = container.clientWidth;
+      canvas.height = container.clientHeight;
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    const stars = Array.from({ length: 200 }, () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      r: Math.random() * 1.5 + 0.5,
+    }));
+
+    const comets = [];
+    const asteroids = [];
+
+    const spawnObject = () => {
+      if (Math.random() < 0.5) {
+        comets.push({
+          x: -50,
+          y: Math.random() * canvas.height,
+          vx: 2 + Math.random() * 3,
+          vy: (Math.random() - 0.5) * 1,
+          radius: 2 + Math.random() * 3,
+          tail: [],
+        });
+      } else {
+        asteroids.push({
+          x: Math.random() * canvas.width,
+          y: -50,
+          vx: (Math.random() - 0.5) * 0.5,
+          vy: 1 + Math.random() * 2,
+          radius: 3 + Math.random() * 4,
+        });
+      }
+    };
+    const spawnInterval = setInterval(spawnObject, 1500);
+
+    const drawStars = () => {
+      ctx.fillStyle = "black";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = "white";
+      stars.forEach((s) => {
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+        ctx.fill();
+      });
+    };
+
+    const animate = () => {
+      drawStars();
+
+      ctx.fillStyle = "white";
+      comets.forEach((c, index) => {
+        c.x += c.vx;
+        c.y += c.vy;
+        c.tail.push({ x: c.x, y: c.y });
+        if (c.tail.length > 10) c.tail.shift();
+        ctx.beginPath();
+        ctx.moveTo(c.x, c.y);
+        for (let t = 0; t < c.tail.length; t++) {
+          const p = c.tail[t];
+          ctx.lineTo(p.x, p.y);
+        }
+        ctx.strokeStyle = "white";
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(c.x, c.y, c.radius, 0, Math.PI * 2);
+        ctx.fill();
+        if (
+          c.x > canvas.width + 50 ||
+          c.y < -50 ||
+          c.y > canvas.height + 50
+        ) {
+          comets.splice(index, 1);
+        }
+      });
+
+      ctx.fillStyle = "#888";
+      asteroids.forEach((a, index) => {
+        a.x += a.vx;
+        a.y += a.vy;
+        ctx.beginPath();
+        ctx.arc(a.x, a.y, a.radius, 0, Math.PI * 2);
+        ctx.fill();
+        if (
+          a.y > canvas.height + 50 ||
+          a.x < -50 ||
+          a.x > canvas.width + 50
+        ) {
+          asteroids.splice(index, 1);
+        }
+      });
+
+      requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      window.removeEventListener("resize", resize);
+      clearInterval(spawnInterval);
+      container.removeChild(canvas);
+    };
+  }, []);
+
+  return <div ref={containerRef} className="absolute inset-0" />;
+}

--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -12,6 +12,8 @@ import { Search, Calendar, ArrowDown } from "lucide-react";
 import FillerContent from "@/components/FillerContent";
 import SampleGraph from "@/SampleGraph.jsx";
 import { ReactFlowProvider } from "@xyflow/react";
+import SpaceScene from "@/components/SpaceScene";
+import NumberTicker from "@/components/NumberTicker";
 
 export default function Goals2() {
   const tilt = (23.5 * Math.PI) / 180;
@@ -22,6 +24,16 @@ export default function Goals2() {
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [collapsed, setCollapsed] = useState(false);
   const searchBarRef = useRef(null);
+  const thirdSectionRef = useRef(null);
+  const [showStickySearch, setShowStickySearch] = useState(false);
+  const dailyUsersStart = useMemo(
+    () => Math.floor(Math.random() * 9000000) + 1000000,
+    []
+  );
+  const graphsGeneratedStart = useMemo(
+    () => Math.floor(Math.random() * 90000000) + 10000000,
+    []
+  );
   const dateOptions = useMemo(() => {
     const dates = [];
     const now = new Date();
@@ -68,8 +80,41 @@ export default function Goals2() {
     return () => window.removeEventListener("scroll", handleScroll);
   }, [graphGenerated]);
 
+  useEffect(() => {
+    const section = thirdSectionRef.current;
+    if (!section) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setShowStickySearch(entry.isIntersecting),
+      { threshold: 0.3 }
+    );
+    observer.observe(section);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div className="min-h-screen bg-white flex flex-col">
+      {showStickySearch && !graphGenerated && (
+        <div className="fixed top-20 left-1/2 -translate-x-1/2 z-50">
+          <div className="bg-[#FFF5EE] rounded-xl shadow p-2 flex items-center">
+            <Input
+              placeholder="type domain here to analyze"
+              value={domain}
+              onChange={(e) => setDomain(e.target.value)}
+              className="w-80 h-12 text-lg rounded-l-full rounded-r-none shadow-inner text-black"
+            />
+            <Button
+              size="icon"
+              variant="secondary"
+              onClick={handleAnalyze}
+              disabled={!domain.trim()}
+              className="rounded-r-full rounded-l-none border-l-0 h-12"
+              type="button"
+            >
+              <Search className="h-6 w-6" />
+            </Button>
+          </div>
+        </div>
+      )}
       <section
         className="relative flex flex-col items-center justify-center h-[calc(100vh-1.5rem-20px)] rounded-3xl overflow-hidden pt-6 pl-6 pr-8 mt-[10px] mx-[10px] mb-[calc(1.5rem+10px)]"
         style={{ backgroundColor: "#8F00FF" }}
@@ -227,6 +272,42 @@ export default function Goals2() {
             </div>
           </div>
         )}
+      </section>
+      <section
+        ref={thirdSectionRef}
+        className="relative flex flex-col items-center h-screen rounded-3xl mx-[10px] mb-[calc(1.5rem+10px)] overflow-hidden bg-black"
+      >
+        <SpaceScene />
+        <h2 className="relative z-10 text-white font-bold text-4xl sm:text-5xl md:text-6xl text-center mt-10">
+          See what our users have to say
+        </h2>
+        <div className="relative z-10 w-72 h-72 md:w-96 md:h-96 mt-10">
+          <GlobeScene
+            modelUrl={lowPolyEarth}
+            onSetRotation={(setRotation) => setRotation({ x: tilt, y: 0 })}
+            distance={1.5}
+          />
+        </div>
+        <div className="relative z-10 mt-auto mb-10 flex gap-16">
+          <div className="text-center">
+            <p className="text-white font-bold text-2xl md:text-3xl">
+              Users Daily
+            </p>
+            <NumberTicker
+              start={dailyUsersStart}
+              className="block text-white font-bold text-4xl md:text-5xl mt-2"
+            />
+          </div>
+          <div className="text-center">
+            <p className="text-white font-bold text-2xl md:text-3xl">
+              Graphs generated so far
+            </p>
+            <NumberTicker
+              start={graphsGeneratedStart}
+              className="block text-white font-bold text-4xl md:text-5xl mt-2"
+            />
+          </div>
+        </div>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- add third space-themed section with zoomed-out globe and animated user stats
- show sticky search bar when scrolling to the final section
- extend GlobeScene with adjustable camera distance

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b196880790832eb4e0c346816dc255