### PR TITLE
Improve Goals2 space section visuals and layout

### DIFF
--- a/src/components/GlobeScene.jsx
+++ b/src/components/GlobeScene.jsx
@@ -15,6 +15,7 @@ export default function GlobeScene({
   mtlUrl = earthMaterial,
   onSetRotation,
   distance = 1,
+  sunLight = false,
 }) {
   const mountRef = useRef(null);
   const globeRef = useRef();
@@ -26,15 +27,23 @@ export default function GlobeScene({
     if (!mount) return;
 
     const scene = new THREE.Scene();
-    // brighter, balanced lighting to remove dark spots
-    const ambientLight = new THREE.AmbientLight(0xffffff, 1.2);
-    scene.add(ambientLight);
-    const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
-    directionalLight.position.set(5, 5, 5);
-    scene.add(directionalLight);
-    const fillLight = new THREE.DirectionalLight(0xffffff, 0.6);
-    fillLight.position.set(-5, -5, -5);
-    scene.add(fillLight);
+    if (sunLight) {
+      const ambientLight = new THREE.AmbientLight(0xffffff, 0.2);
+      scene.add(ambientLight);
+      const sun = new THREE.DirectionalLight(0xffff00, 1.5);
+      sun.position.set(5, 5, 5);
+      scene.add(sun);
+    } else {
+      // brighter, balanced lighting to remove dark spots
+      const ambientLight = new THREE.AmbientLight(0xffffff, 1.2);
+      scene.add(ambientLight);
+      const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
+      directionalLight.position.set(5, 5, 5);
+      scene.add(directionalLight);
+      const fillLight = new THREE.DirectionalLight(0xffffff, 0.6);
+      fillLight.position.set(-5, -5, -5);
+      scene.add(fillLight);
+    }
 
     const camera = new THREE.PerspectiveCamera(
       60,
@@ -289,7 +298,7 @@ export default function GlobeScene({
       if (dotIntervalRef.current) clearInterval(dotIntervalRef.current);
       renderer.dispose();
     };
-  }, [modelUrl, mtlUrl, onSetRotation, distance]);
+  }, [modelUrl, mtlUrl, onSetRotation, distance, sunLight]);
 
   return <div ref={mountRef} className="w-full h-full" />;
 }

--- a/src/components/NumberTicker.jsx
+++ b/src/components/NumberTicker.jsx
@@ -31,5 +31,7 @@ export default function NumberTicker({ start, className = "" }) {
     };
   }, [start]);
 
-  return <span className={className}>{value.toLocaleString()}</span>;
+  return (
+    <span className={`text-white ${className}`}>{value.toLocaleString()}</span>
+  );
 }

--- a/src/components/SpaceScene.jsx
+++ b/src/components/SpaceScene.jsx
@@ -34,7 +34,6 @@ export default function SpaceScene() {
           vx: 2 + Math.random() * 3,
           vy: (Math.random() - 0.5) * 1,
           radius: 2 + Math.random() * 3,
-          tail: [],
         });
       } else {
         asteroids.push({
@@ -62,20 +61,27 @@ export default function SpaceScene() {
     const animate = () => {
       drawStars();
 
-      ctx.fillStyle = "white";
       comets.forEach((c, index) => {
         c.x += c.vx;
         c.y += c.vy;
-        c.tail.push({ x: c.x, y: c.y });
-        if (c.tail.length > 10) c.tail.shift();
+        const angle = Math.atan2(c.vy, c.vx);
+        const tailLength = c.radius * 8;
+        const baseAngle1 = angle + Math.PI / 2;
+        const baseAngle2 = angle - Math.PI / 2;
+        const tipX = c.x - Math.cos(angle) * tailLength;
+        const tipY = c.y - Math.sin(angle) * tailLength;
+        const base1X = c.x + Math.cos(baseAngle1) * c.radius;
+        const base1Y = c.y + Math.sin(baseAngle1) * c.radius;
+        const base2X = c.x + Math.cos(baseAngle2) * c.radius;
+        const base2Y = c.y + Math.sin(baseAngle2) * c.radius;
+        ctx.fillStyle = "rgba(255,255,255,0.8)";
         ctx.beginPath();
-        ctx.moveTo(c.x, c.y);
-        for (let t = 0; t < c.tail.length; t++) {
-          const p = c.tail[t];
-          ctx.lineTo(p.x, p.y);
-        }
-        ctx.strokeStyle = "white";
-        ctx.stroke();
+        ctx.moveTo(base1X, base1Y);
+        ctx.lineTo(base2X, base2Y);
+        ctx.lineTo(tipX, tipY);
+        ctx.closePath();
+        ctx.fill();
+        ctx.fillStyle = "blue";
         ctx.beginPath();
         ctx.arc(c.x, c.y, c.radius, 0, Math.PI * 2);
         ctx.fill();
@@ -88,10 +94,27 @@ export default function SpaceScene() {
         }
       });
 
-      ctx.fillStyle = "#888";
       asteroids.forEach((a, index) => {
         a.x += a.vx;
         a.y += a.vy;
+        const angle = Math.atan2(a.vy, a.vx);
+        const tailLength = a.radius * 6;
+        const baseAngle1 = angle + Math.PI / 2;
+        const baseAngle2 = angle - Math.PI / 2;
+        const tipX = a.x - Math.cos(angle) * tailLength;
+        const tipY = a.y - Math.sin(angle) * tailLength;
+        const base1X = a.x + Math.cos(baseAngle1) * a.radius;
+        const base1Y = a.y + Math.sin(baseAngle1) * a.radius;
+        const base2X = a.x + Math.cos(baseAngle2) * a.radius;
+        const base2Y = a.y + Math.sin(baseAngle2) * a.radius;
+        ctx.fillStyle = "rgba(255,69,0,0.8)";
+        ctx.beginPath();
+        ctx.moveTo(base1X, base1Y);
+        ctx.lineTo(base2X, base2Y);
+        ctx.lineTo(tipX, tipY);
+        ctx.closePath();
+        ctx.fill();
+        ctx.fillStyle = "#888";
         ctx.beginPath();
         ctx.arc(a.x, a.y, a.radius, 0, Math.PI * 2);
         ctx.fill();

--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -275,7 +275,7 @@ export default function Goals2() {
       </section>
       <section
         ref={thirdSectionRef}
-        className="relative flex flex-col items-center h-screen rounded-3xl mx-[10px] mb-[calc(1.5rem+10px)] overflow-hidden bg-black"
+        className="relative flex flex-col items-center h-screen rounded-3xl mx-[10px] mb-[10px] overflow-hidden bg-black"
       >
         <SpaceScene />
         <h2 className="relative z-10 text-white font-bold text-4xl sm:text-5xl md:text-6xl text-center mt-10">
@@ -285,7 +285,8 @@ export default function Goals2() {
           <GlobeScene
             modelUrl={lowPolyEarth}
             onSetRotation={(setRotation) => setRotation({ x: tilt, y: 0 })}
-            distance={1.5}
+            distance={0.9}
+            sunLight
           />
         </div>
         <div className="relative z-10 mt-auto mb-10 flex gap-16">


### PR DESCRIPTION
## Summary
- Zoom 3rd-section globe closer and light it from one yellow "sun" side
- Replace space objects with colored asteroids and comets sporting conical tails
- Trim bottom whitespace to 10px and ensure stats numbers show in white

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b19abc1454832eac2c5f49e8460cdd