### PR TITLE
Refine review globe pins

### DIFF
--- a/src/components/GlobeScene.jsx
+++ b/src/components/GlobeScene.jsx
@@ -25,6 +25,7 @@ export default function GlobeScene({
   const rotationRef = useRef({ x: 0, y: 0 });
   const dotIntervalRef = useRef();
   const radiusRef = useRef(1);
+  const pinRef = useRef();
 
   useEffect(() => {
     const mount = mountRef.current;
@@ -88,16 +89,31 @@ export default function GlobeScene({
 
     const addPin = (lat, lon) => {
       if (!globeRef.current) return;
+      if (pinRef.current) {
+        globeRef.current.remove(pinRef.current);
+        pinRef.current.geometry.dispose();
+        pinRef.current.material.dispose();
+        pinRef.current = null;
+      }
       const radius = radiusRef.current * 1.02;
       const latRad = THREE.MathUtils.degToRad(lat);
       const lonRad = THREE.MathUtils.degToRad(lon);
       const x = radius * Math.cos(latRad) * Math.cos(lonRad);
       const y = radius * Math.sin(latRad);
       const z = radius * Math.cos(latRad) * Math.sin(lonRad);
-      const geometry = new THREE.SphereGeometry(radiusRef.current * 0.03, 8, 8);
+      const height = radiusRef.current * 0.2;
+      const geometry = new THREE.ConeGeometry(
+        radiusRef.current * 0.04,
+        height,
+        8
+      );
+      geometry.translate(0, -height / 2, 0);
       const pin = new THREE.Mesh(geometry, pinMaterial.clone());
       pin.position.set(x, y, z);
+      const dir = new THREE.Vector3(x, y, z).normalize();
+      pin.quaternion.setFromUnitVectors(new THREE.Vector3(0, -1, 0), dir);
       globeRef.current.add(pin);
+      pinRef.current = pin;
     };
 
     const spinTo = (lat, lon) => {

--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -480,7 +480,7 @@ export default function Goals2() {
           See what our users have to say
         </h2>
         <div className="relative z-10 flex items-center w-full h-full">
-          <div className="absolute -left-[10vw] top-1/2 -translate-y-1/2 w-[50vw] h-[50vw] pointer-events-none">
+          <div className="absolute -left-[15vw] top-1/2 -translate-y-1/2 w-[50vw] h-[50vw] pointer-events-none">
             <GlobeScene
               modelUrl={lowPolyEarth}
               distance={1.2}
@@ -494,7 +494,7 @@ export default function Goals2() {
               }}
             />
           </div>
-          <div className="ml-[45vw] mr-4">
+          <div className="ml-[40vw] mr-4">
             <ReviewCarousel reviews={reviews} onNext={handleNextReview} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- shift review section globe further left for better layout
- show only the active location pin as a red cone pointing toward the globe

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b263930dd4832e9036789a94fba580