### PR TITLE
Fix Goals2 statistics text visibility

### DIFF
--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -505,7 +505,7 @@ export default function Goals2() {
             </p>
             <NumberTicker
               start={dailyUsersStart}
-              className="block text-white font-bold text-4xl md:text-5xl mt-2"
+              className="block font-bold text-4xl md:text-5xl mt-2 !text-white"
             />
           </div>
           <div className="text-right">
@@ -514,7 +514,7 @@ export default function Goals2() {
             </p>
             <NumberTicker
               start={graphsGeneratedStart}
-              className="block text-white font-bold text-4xl md:text-5xl mt-2"
+              className="block font-bold text-4xl md:text-5xl mt-2 !text-white"
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Force white text for the "Users Daily" and "Graphs generated so far" statistics in Goals2 to ensure visibility

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2664fbcd8832ea03200ffb3a2114f