### PR TITLE
feat: use Roboto Mono for goals tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
       href="https://fonts.googleapis.com/css2?family=Bungee&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap"
+      rel="stylesheet"
+    />
     <title>Vite + React</title>
   </head>
   <body>

--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -376,7 +376,10 @@ export default function Goals2() {
                             ))}
                           </div>
                         </div>
-                        <span className="text-sm text-gray-700">
+                        <span
+                          className="text-sm text-gray-700"
+                          style={{ fontFamily: '"Roboto Mono", monospace' }}
+                        >
                           {tooltipLabel}
                         </span>
                       </div>


### PR DESCRIPTION
## Summary
- add Roboto Mono font import
- show Goals2 tooltip using Roboto Mono

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b276f05e54832e9d4f2df732516463