### PR TITLE
Smooth search bar animation and extended gradient

### DIFF
--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -279,15 +279,20 @@ export default function Goals2() {
               }}
             >
               Limitless DNSSEC with
-              <span className="bg-gradient-to-r from-pink-500 via-yellow-400 to-purple-500 bg-clip-text !text-transparent animate-gradient mx-2 inline-block">
-                1
+              <span
+                className="bg-clip-text text-transparent animate-gradient mx-2 inline-block"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(90deg,#ec4899,#f97316,#facc15,#10b981,#3b82f6,#8b5cf6)",
+                }}
+              >
+                1 click
               </span>
-              click
             </h2>
             <div
               ref={searchBarRef}
               className={`flex items-center mt-8 w-full max-w-md ${
-                collapseStage >= 1 ? "justify-start" : "justify-center mx-auto"
+                collapseStage >= 2 ? "justify-start" : "justify-center mx-auto"
               }`}
               style={{
                 transform: graphGenerated


### PR DESCRIPTION
## Summary
- Extend gradient across "1 click" with additional colors for a richer effect
- Adjust search bar collapse animation to rise from center before moving sideways

## Testing
- `npm test` *(fails: Missing script: test)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b278efb238832eb69ceb40e13d3ee3