### PR TITLE
Expand 3D viewports on goals page

### DIFF
--- a/src/components/ModelViewer.jsx
+++ b/src/components/ModelViewer.jsx
@@ -7,6 +7,7 @@ export default function ModelViewer({
   autoRotate = true,
   scale = 1,
   initialRotation = { x: 0, y: 0, z: 0 },
+  offset = { x: 0, y: 0, z: 0 },
 }) {
   const mountRef = useRef(null);
 
@@ -44,6 +45,7 @@ export default function ModelViewer({
         camera.position.z = cameraZ * 1.2;
         const center = box.getCenter(new THREE.Vector3());
         model.position.sub(center);
+        model.position.add(new THREE.Vector3(offset.x, offset.y, offset.z));
         model.scale.setScalar(scale);
         model.rotation.set(
           initialRotation.x,
@@ -79,7 +81,7 @@ export default function ModelViewer({
       window.removeEventListener("resize", handleResize);
       mount.removeChild(renderer.domElement);
     };
-  }, [modelUrl, autoRotate, scale, initialRotation]);
+  }, [modelUrl, autoRotate, scale, initialRotation, offset]);
 
   return <div ref={mountRef} className="w-full h-full" />;
 }

--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -437,7 +437,7 @@ export default function Goals2() {
                   <Search className="h-6 w-6" />
                 </Button>
                 <div
-                  className="absolute bottom-full mb-4 left-1/2 -translate-x-1/2 w-40 flex flex-col items-center text-center"
+                  className="absolute bottom-full mb-4 left-1/2 -translate-x-1/2 w-56 flex flex-col items-center text-center"
                   style={{
                     transform:
                       collapseStage >= 3
@@ -448,7 +448,7 @@ export default function Goals2() {
                     willChange: "transform, opacity",
                   }}
                 >
-                  <div className="w-40 h-40 bg-[#FFEDE5] rounded-xl flex items-center justify-center pointer-events-none">
+                  <div className="w-56 h-56 bg-[#FFEDE5] rounded-xl flex items-center justify-center pointer-events-none">
                     <ModelViewer modelUrl={derDenker} scale={1.2} />
                   </div>
                   <h3 className="mt-2 text-xl font-bold">More Modren</h3>
@@ -468,7 +468,7 @@ export default function Goals2() {
                   <ArrowDown className="w-16 h-16" />
                 </p>
                 <div
-                  className="absolute top-1/2 right-full -translate-y-1/2 mr-4 w-32 flex flex-col items-center text-center"
+                  className="absolute top-1/2 right-full -translate-y-1/2 mr-4 w-48 flex flex-col items-center text-center"
                   style={{
                     transform:
                       collapseStage >= 3 ? "translateX(0)" : "translateX(20px)",
@@ -477,14 +477,14 @@ export default function Goals2() {
                     willChange: "transform, opacity",
                   }}
                 >
-                  <div className="w-32 h-32 bg-[#FFE1D4] rounded-xl flex items-center justify-center pointer-events-none">
-                    <ModelViewer modelUrl={animatedClock} scale={1.2} />
+                  <div className="w-48 h-48 bg-[#FFE1D4] rounded-xl flex items-center justify-center pointer-events-none">
+                    <ModelViewer modelUrl={animatedClock} scale={1.2} offset={{ x: 0, y: -0.5, z: 0 }} />
                   </div>
                   <h3 className="mt-2 text-lg font-bold">More History</h3>
                   <p className="text-xs">Lorem ipsum dolor sit amet.</p>
                 </div>
                 <div
-                  className="absolute top-1/2 left-full -translate-y-1/2 ml-4 w-32 flex flex-col items-center text-center"
+                  className="absolute top-1/2 left-full -translate-y-1/2 ml-4 w-48 flex flex-col items-center text-center"
                   style={{
                     transform:
                       collapseStage >= 3
@@ -495,7 +495,7 @@ export default function Goals2() {
                     willChange: "transform, opacity",
                   }}
                 >
-                  <div className="w-32 h-32 bg-[#FFD5C4] rounded-xl flex items-center justify-center pointer-events-none">
+                  <div className="w-48 h-48 bg-[#FFD5C4] rounded-xl flex items-center justify-center pointer-events-none">
                     <ModelViewer modelUrl={lightning} scale={1.2} />
                   </div>
                   <h3 className="mt-2 text-lg font-bold">More Speed</h3>


### PR DESCRIPTION
## Summary
- enlarge Goals2 intro viewports
- add configurable offset for 3D ModelViewer
- lower animated clock model for better framing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b27af37384832ebe9e491513f06fcc