### PR TITLE
Fix null trim error and enable gradient animation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -87,7 +87,7 @@ function HomePage({
               size="icon"
               variant="secondary"
               onClick={handleAnalyze}
-              disabled={!domain.trim() || limitReached}
+              disabled={!(domain || "").trim() || limitReached}
               className="rounded-r-full rounded-l-none border-l-0 h-12 lg:h-14"
               type="button"
             >
@@ -444,7 +444,7 @@ export default function App() {
 
   //graph logic
   const handleAnalyze = () => {
-    const cleaned = domain.trim().toLowerCase();
+    const cleaned = (domain || "").trim().toLowerCase();
     if (!cleaned) return;
     if (!isSignedIn) {
       if (limitReached) {

--- a/src/components/GlobeScene.jsx
+++ b/src/components/GlobeScene.jsx
@@ -393,8 +393,9 @@ export default function GlobeScene({
     };
     document.addEventListener("visibilitychange", visibility);
 
+    let animationFrameId;
     const animate = () => {
-      requestAnimationFrame(animate);
+      animationFrameId = requestAnimationFrame(animate);
       if (paused) return;
       if (globeRef.current) {
         if (autoRotate) {
@@ -404,11 +405,14 @@ export default function GlobeScene({
         globeRef.current.rotation.y = rotationRef.current.y;
       }
       controls.update();
-      renderer.render(scene, camera);
+      if (renderer) {
+        renderer.render(scene, camera);
+      }
     };
     animate();
 
     return () => {
+      cancelAnimationFrame(animationFrameId);
       document.removeEventListener("visibilitychange", visibility);
       window.removeEventListener("resize", handleResize);
       mount.removeChild(renderer.domElement);

--- a/src/index.css
+++ b/src/index.css
@@ -300,5 +300,6 @@ span {
 
 .animate-gradient {
   background-size: 200% 200%;
+  background-position: 0% 50%;
   animation: gradient-shift 3s ease-in-out infinite;
 }

--- a/src/pages/Goals2.jsx
+++ b/src/pages/Goals2.jsx
@@ -116,7 +116,7 @@ export default function Goals2() {
         });
 
   const handleAnalyze = () => {
-    const cleaned = domain.trim().toLowerCase();
+    const cleaned = (domain || "").trim().toLowerCase();
     if (!cleaned) return;
     setCurrentDomain(cleaned);
     setGraphGenerated(true);
@@ -198,7 +198,7 @@ export default function Goals2() {
               size="icon"
               variant="secondary"
               onClick={handleAnalyze}
-              disabled={!domain.trim()}
+              disabled={!(domain || "").trim()}
               className="rounded-r-full rounded-l-none border-l-0 h-12"
               type="button"
             >
@@ -314,7 +314,7 @@ export default function Goals2() {
                 size="icon"
                 variant="secondary"
                 onClick={handleAnalyze}
-                disabled={!domain.trim()}
+                disabled={!(domain || "").trim()}
                 className="rounded-r-full rounded-l-none border-l-0 h-12 lg:h-14"
                 type="button"
               >
@@ -434,7 +434,7 @@ export default function Goals2() {
                   size="icon"
                   variant="secondary"
                   onClick={handleAnalyze}
-                  disabled={!domain.trim()}
+                  disabled={!(domain || "").trim()}
                   className="rounded-r-full rounded-l-none border-l-0 h-12"
                   type="button"
                 >


### PR DESCRIPTION
## Summary
- Prevent null `.trim()` crashes by guarding domain inputs
- Stop globe animation after unmount to avoid runtime errors
- Restore shifting color gradient for “1 click” headline

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b28242b3e0832e99ef259f472a4b69